### PR TITLE
Fix 2 problems

### DIFF
--- a/ext/src/swow_coroutine.c
+++ b/ext/src/swow_coroutine.c
@@ -1069,6 +1069,7 @@ SWOW_API cat_bool_t swow_coroutine_set_local_var(swow_coroutine_t *scoroutine, z
 
         SWOW_COROUTINE_CHECK_CALL_INFO(goto _error);
 
+        Z_ADDREF_P(value);
         error = zend_set_local_var(name, value, force);
 
         if (UNEXPECTED(error != SUCCESS)) {

--- a/ext/src/swow_defer.c
+++ b/ext/src/swow_defer.c
@@ -54,6 +54,7 @@ SWOW_API cat_bool_t swow_defer(zval *zcallable)
             zend_object *defer = swow_object_create(swow_defer_ce);
             zval zdefer;
             ZVAL_OBJ(&zdefer, defer);
+            Z_ADDREF_P(&zdefer);
             /* zend_hash_str_add_new is macro on PHP-7.x, so we can not use ZEND_STRL here */
             zend_hash_str_add_new(symbol_table, SWOW_DEFER_MAGIC_NAME, sizeof(SWOW_DEFER_MAGIC_NAME) - 1, &zdefer);
             sdefer = swow_defer_get_from_object(defer);

--- a/ext/tests/swow_defer/defer_and_exit.phpt
+++ b/ext/tests/swow_defer/defer_and_exit.phpt
@@ -1,0 +1,26 @@
+--TEST--
+swow_defer: defer and exit
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.php';
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use function Swow\defer;
+
+defer(function () {
+    echo '1' . PHP_LF;
+});
+defer(function () {
+    echo '2' . PHP_LF;
+});
+
+echo 'Done' . PHP_LF;
+
+?>
+--EXPECT--
+Done
+2
+1


### PR DESCRIPTION
## Problem 1

```php
<?php

declare(strict_types=1);

namespace Test
{
    use ArrayObject;
    use Swow\Coroutine;
    use function Swow\Sync\waitAll;

    class Context extends ArrayObject
    {
        public function __destruct()
        {
            var_dump(__METHOD__);
        }
    }

    Coroutine::run(function () {
        Coroutine::getCurrent()->setLocalVar('a', new Context());
        var_dump(Coroutine::getCurrent()->getDefinedVars()['a']);
    });

    waitAll();
}
```

![06cbe712d8c27b37e693f0425b5d275](https://user-images.githubusercontent.com/20104656/157412745-5ddb5ff2-1b78-4964-aced-962e8dc5e402.png)

## Problem 2

After exit in the coroutine, defer is not executed.

```php
<?php

use Swow\Coroutine;

use function Swow\defer;

Coroutine::run(function(){
    defer(function () {
        echo '1' . PHP_EOL;
    });
    defer(function () {
        echo '2' . PHP_EOL;
    });
    exit;
});
```
