### PR TITLE
Optimize test coverage for library

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Run library tests
         id: test-library
         continue-on-error: true
-        run: php --ri pcov && composer test-library-coverage
+        run: php --ri pcov && composer test-library-with-pcov
 
       - name: Fail if test-extension failed
         if: steps.test-extension.outcome != 'success'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,10 +55,10 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           tools: phpize
-          ini-values: pcov.enabled = 1
+          ini-values: pcov.enabled = 0
           coverage: pcov
           # coverage: none
-          extensions: curl,openssl,sockets,ffi,pcov
+          extensions: curl,openssl,sockets,ffi
         #env:
           #phpts: ${{ matrix.ts }}
 
@@ -91,7 +91,7 @@ jobs:
       - name: Run library tests
         id: test-library
         continue-on-error: true
-        run: php --ri pcov && composer test-library
+        run: php --ri pcov && composer test-library-coverage
 
       - name: Fail if test-extension failed
         if: steps.test-extension.outcome != 'success'

--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
         "install-clean-debug-extension": [ "@install-debug-extension --clean" ],
         "test-extension": [ "@php tools/test-extension.php" ],
         "test-library": [ "@swow-php vendor/bin/phpunit --configuration lib/swow-library lib/swow-library" ],
-        "test-library-coverage": [ "@swow-php -dextension=pcov -dpcov.enabled=1 vendor/bin/phpunit --configuration lib/swow-library lib/swow-library" ],
+        "test-library-with-pcov": [ "@swow-php -dextension=pcov -dpcov.enabled=1 vendor/bin/phpunit --configuration lib/swow-library lib/swow-library" ],
         "test": [ "@test-extension", "@test-library" ],
         "gen-stub": [
             "@swow-php lib/php-stub-generator/bin/gen-stub.php --noinspection --stub-file=lib/swow-stub/src/Swow.php swow lib/swow-stub/src/Swow.php",

--- a/composer.json
+++ b/composer.json
@@ -91,6 +91,7 @@
         "install-clean-debug-extension": [ "@install-debug-extension --clean" ],
         "test-extension": [ "@php tools/test-extension.php" ],
         "test-library": [ "@swow-php vendor/bin/phpunit --configuration lib/swow-library lib/swow-library" ],
+        "test-library-coverage": [ "@swow-php -dextension=pcov -dpcov.enabled=1 vendor/bin/phpunit --configuration lib/swow-library lib/swow-library" ],
         "test": [ "@test-extension", "@test-library" ],
         "gen-stub": [
             "@swow-php lib/php-stub-generator/bin/gen-stub.php --noinspection --stub-file=lib/swow-stub/src/Swow.php swow lib/swow-stub/src/Swow.php",


### PR DESCRIPTION
Only enable pcov extension when testing the library