### PR TITLE
add --with-php-config option

### DIFF
--- a/ext/bin/swow-builder
+++ b/ext/bin/swow-builder
@@ -49,7 +49,7 @@ if (PHP_OS_FAMILY === 'Windows') {
 $workSpace = dirname(__DIR__);
 
 $swowSo = "{$workSpace}/.libs/swow.so";
-$options = getopt('', ['sudo', 'install', 'rebuild', 'clean', 'show-log', 'debug', 'thread-context', 'msan', 'asan', 'ubsan', 'enable::']);
+$options = getopt('', ['sudo', 'install', 'rebuild', 'clean', 'show-log', 'debug', 'thread-context', 'msan', 'asan', 'ubsan', 'enable::','with-php-config::']);
 
 $commandExecutor = static function (string $name, array $commands) use ($workSpace): void {
     if (!$commands) {
@@ -95,6 +95,9 @@ if (!file_exists("{$workSpace}/Makefile") || isset($options['rebuild'])) {
     }
     if (isset($options['enable'])) {
         $configureOptions[] = $options['enable'];
+    }
+    if (isset($options['with-php-config'])) {
+        $configureOptions[] = '--with-php-config='.$options['with-php-config'];
     }
     $configureOptions = implode(' ', $configureOptions);
     $configureCommands[] = "./configure {$configureOptions}";

--- a/ext/bin/swow-builder
+++ b/ext/bin/swow-builder
@@ -97,7 +97,7 @@ if (!file_exists("{$workSpace}/Makefile") || isset($options['rebuild'])) {
         $configureOptions[] = $options['enable'];
     }
     if (isset($options['with-php-config'])) {
-        $configureOptions[] = '--with-php-config='.$options['with-php-config'];
+        $configureOptions[] = '--with-php-config=' . $options['with-php-config'];
     }
     $configureOptions = implode(' ', $configureOptions);
     $configureCommands[] = "./configure {$configureOptions}";


### PR DESCRIPTION
```
root@D012016120178:/mnt/f/Code/swow-test# ./vendor/bin/swow-builder --with-php-config=3232 
> cd /mnt/f/Code/swow-test/vendor/swow/swow/ext && \ 
./configure 
checking for grep that handles long lines and -e... /usr/bin/grep 
checking for egrep... /usr/bin/grep -E 
checking for a sed that does not truncate output... /usr/bin/sed 
checking for pkg-config... /usr/bin/pkg-config 
checking pkg-config is at least version 0.9.0... yes 
checking for cc... cc 
checking whether the C compiler works... yes 
checking for C compiler default output file name... a.out 
checking for suffix of executables... 
checking whether we are cross compiling... no 
checking for suffix of object files... o 
checking whether the compiler supports GNU C... yes 
checking whether cc accepts -g... yes 
checking for cc option to enable C11 features... none needed 
checking how to run the C preprocessor... cc -E 
checking for icc... no 
checking for suncc... no 
checking for system library directory... lib 
checking if compiler supports -Wl,-rpath,... yes 
checking build system type... x86_64-pc-linux-gnu 
checking host system type... x86_64-pc-linux-gnu 
checking target system type... x86_64-pc-linux-gnu 
configure: error: Cannot find php-config. Please use --with-php-config=PATH 
 Configure failed 
```

支持指定php-config  