### PR TITLE
fix setParsedBody params type

### DIFF
--- a/lib/swow-library/lib/psr7-plus/src/Message/ServerRequest.php
+++ b/lib/swow-library/lib/psr7-plus/src/Message/ServerRequest.php
@@ -34,7 +34,7 @@ class ServerRequest extends Request implements ServerRequestPlusInterface
     protected array $queryParams = [];
 
     /** @var null|array<mixed>|object */
-    protected array|object|null $parsedBody;
+    protected null|array|object $parsedBody;
 
     protected ?int $contentLength = null;
 

--- a/lib/swow-library/lib/psr7-plus/src/Message/ServerRequest.php
+++ b/lib/swow-library/lib/psr7-plus/src/Message/ServerRequest.php
@@ -33,8 +33,8 @@ class ServerRequest extends Request implements ServerRequestPlusInterface
     /** @var array<string, string> */
     protected array $queryParams = [];
 
-    /** @var array<mixed>|object */
-    protected array|object $parsedBody;
+    /** @var null|array<mixed>|object */
+    protected array|object|null $parsedBody;
 
     protected ?int $contentLength = null;
 

--- a/lib/swow-library/lib/psr7-plus/src/Message/ServerRequest.php
+++ b/lib/swow-library/lib/psr7-plus/src/Message/ServerRequest.php
@@ -152,7 +152,7 @@ class ServerRequest extends Request implements ServerRequestPlusInterface
     }
 
     /** @param array<mixed>|object $data */
-    public function setParsedBody(array|object $data): static
+    public function setParsedBody(null|array|object $data): static
     {
         $this->parsedBody = $data;
 

--- a/lib/swow-library/lib/psr7-plus/src/Message/ServerRequest.php
+++ b/lib/swow-library/lib/psr7-plus/src/Message/ServerRequest.php
@@ -151,7 +151,7 @@ class ServerRequest extends Request implements ServerRequestPlusInterface
         return $this->parsedBody ??= BodyDecoder::decode($this->getBody(), $this->getContentType());
     }
 
-    /** @param array<mixed>|object $data */
+    /** @param null|array<mixed>|object $data */
     public function setParsedBody(null|array|object $data): static
     {
         $this->parsedBody = $data;

--- a/lib/swow-library/lib/psr7-plus/src/Message/ServerRequest.php
+++ b/lib/swow-library/lib/psr7-plus/src/Message/ServerRequest.php
@@ -33,8 +33,8 @@ class ServerRequest extends Request implements ServerRequestPlusInterface
     /** @var array<string, string> */
     protected array $queryParams = [];
 
-    /** @var null|array<mixed>|object */
-    protected null|array|object $parsedBody;
+    /** @var array<mixed>|object|null */
+    protected array|object|null $parsedBody;
 
     protected ?int $contentLength = null;
 
@@ -151,8 +151,8 @@ class ServerRequest extends Request implements ServerRequestPlusInterface
         return $this->parsedBody ??= BodyDecoder::decode($this->getBody(), $this->getContentType());
     }
 
-    /** @param null|array<mixed>|object $data */
-    public function setParsedBody(null|array|object $data): static
+    /** @param array<mixed>|object|null $data */
+    public function setParsedBody(array|object|null $data): static
     {
         $this->parsedBody = $data;
 


### PR DESCRIPTION
The PSR-7 standard protocol allows the types that can be written with withParsedBody to be null, array, or object. However, using the Psr library from the standard library will result in a type error. Please refer to this address for more information.
 https://github.com/php-fig/http-message/blob/efd67d1dc14a7ef4fc4e518e7dee91c271d524e4/src/ServerRequestInterface.php#L197