### PR TITLE
Fix memory error due to call destructor in scheduler

### DIFF
--- a/ext/include/swow_wrapper.h
+++ b/ext/include/swow_wrapper.h
@@ -296,6 +296,8 @@ static zend_always_inline zend_object* swow_object_create(zend_class_entry *ce)
     return ce->create_object(ce);
 }
 
+SWOW_API void swow_object_properties_clean(zend_object *object);
+
 #ifndef Z_OBJCENAME_P
 #define Z_OBJCENAME_P(zobject) ZSTR_VAL(Z_OBJCE_P(zobject)->name)
 #endif

--- a/ext/tests/swow_coroutine/extends_properties_destruction.phpt
+++ b/ext/tests/swow_coroutine/extends_properties_destruction.phpt
@@ -35,7 +35,7 @@ foreach ([false, true] as $throwError) {
         }
     })->resume();
     msleep(1);
-    echo str_repeat('-', 32) . "\n";
+    echo "\n";
 }
 
 (new class(static function (): void {
@@ -58,7 +58,7 @@ foreach ([false, true] as $throwError) {
     }
 })->resume();
 msleep(1);
-echo str_repeat('-', 32) . "\n";
+echo "\n";
 
 echo "Done\n";
 
@@ -66,17 +66,17 @@ echo "Done\n";
 --EXPECTF--
 Destruct
 bool(true)
---------------------------------
+
 Destruct
 bool(true)
 
-Warning: [Fatal error in R%s] Uncaught Error in %s/tests/swow_coroutine/extends_properties_destruction.php:%d
+Warning: [Fatal error in R%d] Uncaught Error in %s/tests/swow_coroutine/extends_properties_destruction.php:%d
 Stack trace:
 #0 [internal function]: class@anonymous->__destruct()
 #1 {main}
   thrown in %s/tests/swow_coroutine/extends_properties_destruction.php on line %d
---------------------------------
+
 Destruct
 bool(false)
---------------------------------
+
 Done

--- a/ext/tests/swow_coroutine/extends_properties_destruction.phpt
+++ b/ext/tests/swow_coroutine/extends_properties_destruction.phpt
@@ -1,0 +1,82 @@
+--TEST--
+swow_coroutine: extends properties destruction
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.php';
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swow\Coroutine;
+
+foreach ([false, true] as $throwError) {
+    (new class(static function (): void {
+        msleep(0);
+    }, $throwError) extends Coroutine {
+        public object $aaa;
+        public bool $throwError;
+
+        public function __construct(callable $callable, bool $throwError)
+        {
+            parent::__construct($callable);
+            $this->aaa = new class() {
+                public function __destruct()
+                {
+                    echo "Destruct\n";
+                    var_dump(Coroutine::getCurrent()->aaa === $this);
+                    $throwError = Coroutine::getCurrent()->throwError;
+                    if ($throwError) {
+                        throw new Error();
+                    }
+                }
+            };
+            $this->throwError = $throwError;
+        }
+    })->resume();
+    msleep(1);
+    echo str_repeat('-', 32) . "\n";
+}
+
+(new class(static function (): void {
+    msleep(0);
+}) extends Coroutine {
+    public bool $bbb;
+    public object $aaa;
+
+    public function __construct(callable $callable)
+    {
+        parent::__construct($callable);
+        $this->bbb = true;
+        $this->aaa = new class() {
+            public function __destruct()
+            {
+                echo "Destruct\n";
+                var_dump(isset(Coroutine::getCurrent()->bbb));
+            }
+        };
+    }
+})->resume();
+msleep(1);
+echo str_repeat('-', 32) . "\n";
+
+echo "Done\n";
+
+?>
+--EXPECTF--
+Destruct
+bool(true)
+--------------------------------
+Destruct
+bool(true)
+
+Warning: [Fatal error in R%s] Uncaught Error in %s/tests/swow_coroutine/extends_properties_destruction.php:%d
+Stack trace:
+#0 [internal function]: class@anonymous->__destruct()
+#1 {main}
+  thrown in %s/tests/swow_coroutine/extends_properties_destruction.php on line %d
+--------------------------------
+Destruct
+bool(false)
+--------------------------------
+Done

--- a/ext/tests/swow_coroutine/extends_properties_destruction.phpt
+++ b/ext/tests/swow_coroutine/extends_properties_destruction.phpt
@@ -70,11 +70,11 @@ bool(true)
 Destruct
 bool(true)
 
-Warning: [Fatal error in R%d] Uncaught Error in %s/tests/swow_coroutine/extends_properties_destruction.php:%d
+Warning: [Fatal error in R%d] Uncaught Error in %sextends_properties_destruction.php:%d
 Stack trace:
 #0 [internal function]: class@anonymous->__destruct()
 #1 {main}
-  thrown in %s/tests/swow_coroutine/extends_properties_destruction.php on line %d
+  thrown in %sextends_properties_destruction.php on line %d
 
 Destruct
 bool(false)


### PR DESCRIPTION
As the Coroutine class can be inherited, developers can define more properties on Coroutines. When a Coroutine is released in the scheduler, the properties on the Coroutine will also be released. If some of these properties have a destructor function, the destructor function will be called in the scheduler. However, the scheduler does not have a PHP stack, which can lead to memory errors. The solution is to clean all property values after the Coroutine function has finished running.