### PR TITLE
🚀:Add return type to recvMessage method And Add maximum log file size and SIGHUP signal handling

### DIFF
--- a/lib/dontdie/bin/dontdie
+++ b/lib/dontdie/bin/dontdie
@@ -44,6 +44,8 @@ use const JSON_THROW_ON_ERROR;
 use const JSON_UNESCAPED_SLASHES;
 use const STDERR;
 
+const MAX_FILE_SIZE = 1024 * 1024;
+
 /** @param string[] $command */
 function dontDie(array $command, string $nickname = '', int $maxExecutionTime = -1): void
 {
@@ -69,6 +71,9 @@ function dontDie(array $command, string $nickname = '', int $maxExecutionTime = 
             $logFilename = $cwd . '/.dontdie.' . $nickname . '.log';
         }
         $log = static function (string|array $contents) use ($pid, $logFilename): void {
+            if (file_exists($logFilename) && filesize($logFilename) > MAX_FILE_SIZE) { // If logFileSize > 1MB,Avoid adding logs all the time, causing files to become too large
+                rename($logFilename, $logFilename.'.old'); // Rename it to .old
+            }
             $line =
                 json_encode([
                     'pid' => $pid,
@@ -109,6 +114,7 @@ function dontDie(array $command, string $nickname = '', int $maxExecutionTime = 
         };
         $sigintWorker = Coroutine::run($signalProxy, Signal::INT);
         $sigtermWorker = Coroutine::run($signalProxy, Signal::TERM);
+        $sighupWorker = Coroutine::run($signalProxy, Signal::HUP);
 
         $trace('wait for process');
         try {
@@ -127,6 +133,9 @@ function dontDie(array $command, string $nickname = '', int $maxExecutionTime = 
         }
         if ($sigtermWorker->isExecuting()) {
             $sigtermWorker->kill();
+        }
+        if($sighupWorker->isExecuting()){
+            $sighupWorker->kill();
         }
         $trace('wait for process exit');
         for ($i = 0; $i < 110; $i++) {

--- a/lib/swow-library/src/Stream/EofStream.php
+++ b/lib/swow-library/src/Stream/EofStream.php
@@ -65,7 +65,7 @@ class EofStream extends Socket
      * @param ?int $offset default value is $buffer->getLength()
      * @return int message length
      */
-    public function recvMessage(Buffer $buffer, ?int $offset = null, ?int $timeout = null)
+    public function recvMessage(Buffer $buffer, ?int $offset = null, ?int $timeout = null): int
     {
         $offset ??= $buffer->getLength();
         $internalBuffer = $this->internalBuffer;


### PR DESCRIPTION
The 'recvMessage' method in 'EofStream.php' has been updated to explicitly declare its return type as 'int'. This change ensures type safety and makes the code more readable and maintainable.