### PR TITLE
Add return type to recvMessage method

### DIFF
--- a/lib/swow-library/src/Stream/EofStream.php
+++ b/lib/swow-library/src/Stream/EofStream.php
@@ -65,7 +65,7 @@ class EofStream extends Socket
      * @param ?int $offset default value is $buffer->getLength()
      * @return int message length
      */
-    public function recvMessage(Buffer $buffer, ?int $offset = null, ?int $timeout = null)
+    public function recvMessage(Buffer $buffer, ?int $offset = null, ?int $timeout = null): int
     {
         $offset ??= $buffer->getLength();
         $internalBuffer = $this->internalBuffer;


### PR DESCRIPTION
A return type int has been added to the recvMessage method in the EofStream class. This ensures that the method always returns an integer, enhancing code robustness and readability.