### PR TITLE
Handle SIGHUP signal in dontdie

### DIFF
--- a/lib/dontdie/bin/dontdie
+++ b/lib/dontdie/bin/dontdie
@@ -20,6 +20,7 @@ use Swow\Coroutine;
 use Swow\Signal;
 use Swow\Sync\WaitReference;
 use Swow\SyncException;
+
 use function array_slice;
 use function date;
 use function extension_loaded;
@@ -37,6 +38,7 @@ use function proc_open;
 use function sleep;
 use function sprintf;
 use function usleep;
+
 use const FILE_APPEND;
 use const JSON_THROW_ON_ERROR;
 use const JSON_UNESCAPED_SLASHES;

--- a/lib/dontdie/bin/dontdie
+++ b/lib/dontdie/bin/dontdie
@@ -20,7 +20,6 @@ use Swow\Coroutine;
 use Swow\Signal;
 use Swow\Sync\WaitReference;
 use Swow\SyncException;
-
 use function array_slice;
 use function date;
 use function extension_loaded;
@@ -38,7 +37,6 @@ use function proc_open;
 use function sleep;
 use function sprintf;
 use function usleep;
-
 use const FILE_APPEND;
 use const JSON_THROW_ON_ERROR;
 use const JSON_UNESCAPED_SLASHES;
@@ -72,7 +70,7 @@ function dontDie(array $command, string $nickname = '', int $maxExecutionTime = 
         }
         $log = static function (string|array $contents) use ($pid, $logFilename): void {
             if (file_exists($logFilename) && filesize($logFilename) > MAX_FILE_SIZE) { // If logFileSize > 1MB,Avoid adding logs all the time, causing files to become too large
-                rename($logFilename, date('YmdHis').'.old'); // Rename it to YmdHis.old
+                rename($logFilename, date('YmdHis') . '.old'); // Rename it to YmdHis.old
             }
             $line =
                 json_encode([
@@ -124,18 +122,10 @@ function dontDie(array $command, string $nickname = '', int $maxExecutionTime = 
             $trace('wait for process timeout or canceled');
             Signal::kill($status['pid'], Signal::TERM);
         }
-
-        if ($stderrWorker->isExecuting()) {
-            $stderrWorker->kill();
-        }
-        if ($sigintWorker->isExecuting()) {
-            $sigintWorker->kill();
-        }
-        if ($sigtermWorker->isExecuting()) {
-            $sigtermWorker->kill();
-        }
-        if($sighupWorker->isExecuting()){
-            $sighupWorker->kill();
+        foreach ([$stderrWorker, $sigintWorker, $sigtermWorker, $sighupWorker] as $worker) {
+            if ($worker->isExecuting()) {
+                $worker->kill();
+            }
         }
 
         $trace('wait for process exit');

--- a/lib/dontdie/bin/dontdie
+++ b/lib/dontdie/bin/dontdie
@@ -44,6 +44,8 @@ use const JSON_THROW_ON_ERROR;
 use const JSON_UNESCAPED_SLASHES;
 use const STDERR;
 
+const MAX_FILE_SIZE = 1024 * 1024;
+
 /** @param string[] $command */
 function dontDie(array $command, string $nickname = '', int $maxExecutionTime = -1): void
 {
@@ -69,6 +71,9 @@ function dontDie(array $command, string $nickname = '', int $maxExecutionTime = 
             $logFilename = $cwd . '/.dontdie.' . $nickname . '.log';
         }
         $log = static function (string|array $contents) use ($pid, $logFilename): void {
+            if (file_exists($logFilename) && filesize($logFilename) > MAX_FILE_SIZE) { // If logFileSize > 1MB,Avoid adding logs all the time, causing files to become too large
+                rename($logFilename, date('YmdHis').'.old'); // Rename it to YmdHis.old
+            }
             $line =
                 json_encode([
                     'pid' => $pid,
@@ -109,6 +114,7 @@ function dontDie(array $command, string $nickname = '', int $maxExecutionTime = 
         };
         $sigintWorker = Coroutine::run($signalProxy, Signal::INT);
         $sigtermWorker = Coroutine::run($signalProxy, Signal::TERM);
+        $sighupWorker = Coroutine::run($signalProxy, Signal::HUP);
 
         $trace('wait for process');
         try {
@@ -128,6 +134,10 @@ function dontDie(array $command, string $nickname = '', int $maxExecutionTime = 
         if ($sigtermWorker->isExecuting()) {
             $sigtermWorker->kill();
         }
+        if($sighupWorker->isExecuting()){
+            $sighupWorker->kill();
+        }
+
         $trace('wait for process exit');
         for ($i = 0; $i < 110; $i++) {
             if (!$status['running']) {
@@ -161,6 +171,8 @@ if (!extension_loaded('swow')) {
 if ($argc <= 1) {
     throw new InvalidArgumentException('No command specified');
 }
+
+date_default_timezone_set('Asia/Shanghai');
 
 $options = getopt('', ['nickname:'], $restIndex);
 $command = array_slice($argv, $restIndex);

--- a/lib/dontdie/bin/dontdie
+++ b/lib/dontdie/bin/dontdie
@@ -16,7 +16,6 @@ namespace DontDie;
 
 use InvalidArgumentException;
 use RuntimeException;
-use SplFileInfo;
 use Swow\Coroutine;
 use Swow\Signal;
 use Swow\Sync\WaitReference;
@@ -45,8 +44,6 @@ use const JSON_THROW_ON_ERROR;
 use const JSON_UNESCAPED_SLASHES;
 use const STDERR;
 
-const MAX_FILE_SIZE = 1024 * 1024;
-
 /** @param string[] $command */
 function dontDie(array $command, string $nickname = '', int $maxExecutionTime = -1): void
 {
@@ -72,10 +69,6 @@ function dontDie(array $command, string $nickname = '', int $maxExecutionTime = 
             $logFilename = $cwd . '/.dontdie.' . $nickname . '.log';
         }
         $log = static function (string|array $contents) use ($pid, $logFilename): void {
-            $file = new SplFileInfo($logFilename);
-            if ($file->getRealPath() && $file->getSize() > MAX_FILE_SIZE) { // If logFileSize > 1MB,Avoid adding logs all the time, causing files to become too large
-                rename($logFilename, date('YmdHis') . '.old'); // Rename it to YmdHis.old
-            }
             $line =
                 json_encode([
                     'pid' => $pid,
@@ -165,8 +158,6 @@ if (!extension_loaded('swow')) {
 if ($argc <= 1) {
     throw new InvalidArgumentException('No command specified');
 }
-
-date_default_timezone_set('Asia/Shanghai');
 
 $options = getopt('', ['nickname:'], $restIndex);
 $command = array_slice($argv, $restIndex);

--- a/lib/dontdie/bin/dontdie
+++ b/lib/dontdie/bin/dontdie
@@ -16,6 +16,7 @@ namespace DontDie;
 
 use InvalidArgumentException;
 use RuntimeException;
+use SplFileInfo;
 use Swow\Coroutine;
 use Swow\Signal;
 use Swow\Sync\WaitReference;
@@ -71,7 +72,8 @@ function dontDie(array $command, string $nickname = '', int $maxExecutionTime = 
             $logFilename = $cwd . '/.dontdie.' . $nickname . '.log';
         }
         $log = static function (string|array $contents) use ($pid, $logFilename): void {
-            if (file_exists($logFilename) && filesize($logFilename) > MAX_FILE_SIZE) { // If logFileSize > 1MB,Avoid adding logs all the time, causing files to become too large
+            $file = new SplFileInfo($logFilename);
+            if ($file->getRealPath() && $file->getSize() > MAX_FILE_SIZE) { // If logFileSize > 1MB,Avoid adding logs all the time, causing files to become too large
                 rename($logFilename, date('YmdHis') . '.old'); // Rename it to YmdHis.old
             }
             $line =


### PR DESCRIPTION
The implemented features include a specification for a maximum file size of log files to prevent them from becoming too large. Also, added a handler for SIGHUP signals in order to intuitive processes control. Furthermore, set Shanghai as the default timezone.