### PR TITLE
Update namespace in stream tests

### DIFF
--- a/lib/swow-library/tests/Stream/EofStreamTest.php
+++ b/lib/swow-library/tests/Stream/EofStreamTest.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace SwowTest\Stream;
+namespace Swow\Tests\Stream;
 
 use PHPUnit\Framework\TestCase;
 use Swow\Coroutine;

--- a/lib/swow-library/tests/Stream/JsonStreamTest.php
+++ b/lib/swow-library/tests/Stream/JsonStreamTest.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace SwowTest\Stream;
+namespace Swow\Tests\Stream;
 
 use PHPUnit\Framework\TestCase;
 use Swow\Coroutine;

--- a/lib/swow-library/tests/Stream/VarStreamTest.php
+++ b/lib/swow-library/tests/Stream/VarStreamTest.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace SwowTest\Stream;
+namespace Swow\Tests\Stream;
 
 use PHPUnit\Framework\TestCase;
 use stdClass;


### PR DESCRIPTION
This commit updates the namespace used in VarStreamTest.php, JsonStreamTest.php, and EofStreamTest.php files. The old namespaces were erroneous, so they have been corrected to 'Swow\Tests\Stream' to align with the rest of the project.