### PR TITLE
Update PHP version in GitHub workflows

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ["8.2", "8.1", "8.0"]
+        php-version: ["8.3", "8.2", "8.1", "8.0"]
         arch: ["x64"]
         ts: ["0", "1"]
       max-parallel: 8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.2', '8.1', '8.0']
+        php-version: ['8.3', '8.2', '8.1', '8.0']
         #php-version: ['8.0']
         #ts: ['nts', 'ts']
       max-parallel: 3
@@ -148,7 +148,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.2', '8.1', '8.0']
+        php-version: ['8.3', '8.2', '8.1', '8.0']
         #php-version: ['8.0']
         #ts: ['nts', 'ts']
       max-parallel: 3
@@ -259,7 +259,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ["8.2", "8.1", "8.0"]
+        php-version: ["8.3", "8.2", "8.1", "8.0"]
         ts: [ 'nts', 'ts' ]
       max-parallel: 8
     steps:


### PR DESCRIPTION
The PHP version in the matrix configuration of multiple GitHub workflows has been updated. The newer version, 8.3, has been added to the versions array while maintaining the existing versions, in order to test compatibility and performance with the latest PHP update.