### PR TITLE
feat(h2): add production-ready HTTP/2 server runtime 

### DIFF
--- a/examples/http_server/h2-runtime-checks.php
+++ b/examples/http_server/h2-runtime-checks.php
@@ -1,0 +1,291 @@
+<?php
+
+declare(strict_types=1);
+
+use Swow\Http\Protocol\H2Connection;
+use Swow\Http\Protocol\H2Frame;
+use Swow\Http\Protocol\H2Headers;
+use Swow\Http\Protocol\H2Hpack;
+use Swow\Socket;
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+const H2_CHECK_SETTINGS_TIMEOUT = 1000;
+const H2_CHECK_READ_TIMEOUT = 3000;
+const H2_CHECK_INITIAL_WINDOW = 1024;
+const H2_CHECK_STREAM_PRIMARY = 1;
+const H2_CHECK_STREAM_SECONDARY = 3;
+const H2_CHECK_STREAM_TERTIARY = 5;
+
+if ($argc < 3) {
+    fwrite(STDERR, "Usage: php examples/http_server/h2-runtime-checks.php <trailers|multistream> <port>\n");
+    exit(1);
+}
+
+$mode = $argv[1];
+$port = (int) $argv[2];
+
+$socket = (new Socket(Socket::TYPE_TCP))->connect('127.0.0.1', $port);
+$connection = new H2Connection($socket);
+$decoder = new H2Hpack();
+
+sendClientPrefaceAndSettings(
+    $socket,
+    $connection,
+    $mode === 'multistream' ? H2_CHECK_INITIAL_WINDOW : null
+);
+
+match ($mode) {
+    'trailers' => runTrailerCheck($connection, $decoder, $port),
+    'multistream' => runMultiStreamCheck($connection, $port),
+    default => throw new InvalidArgumentException('Unsupported mode: ' . $mode),
+};
+
+$socket->close();
+
+function runTrailerCheck(H2Connection $connection, H2Hpack $decoder, int $port): void
+{
+    sendRequestWithTrailers($connection, $port);
+    sendResponseTrailerRequest($connection, $port);
+
+    $echoBody = '';
+    $responseTrailerBody = '';
+    $responseTrailers = [];
+    $echoDone = false;
+    $trailerDone = false;
+
+    while (!$echoDone || !$trailerDone) {
+        $frame = readUsefulFrame($connection);
+
+        if ($frame->streamId === H2_CHECK_STREAM_PRIMARY) {
+            if ($frame->type === H2Frame::TYPE_DATA) {
+                $echoBody .= $frame->payload;
+                if (($frame->flags & H2Frame::FLAG_END_STREAM) !== 0) {
+                    $echoDone = true;
+                }
+            }
+            continue;
+        }
+
+        if ($frame->streamId !== H2_CHECK_STREAM_SECONDARY) {
+            continue;
+        }
+
+        if ($frame->type === H2Frame::TYPE_DATA) {
+            $responseTrailerBody .= $frame->payload;
+            continue;
+        }
+
+        if ($frame->type === H2Frame::TYPE_HEADERS) {
+            $decoded = $decoder->decode(readHeaderBlock($connection, $frame));
+            if (($frame->flags & H2Frame::FLAG_END_STREAM) !== 0) {
+                $responseTrailers = H2Headers::createTrailerMap($decoded);
+                $trailerDone = true;
+            }
+        }
+    }
+
+    echo 'REQUEST_TRAILER_RESPONSE=' . $echoBody . PHP_EOL;
+    echo 'RESPONSE_TRAILER_BODY=' . $responseTrailerBody . PHP_EOL;
+    echo 'RESPONSE_TRAILERS=' . json_encode($responseTrailers, JSON_UNESCAPED_UNICODE) . PHP_EOL;
+}
+
+function runMultiStreamCheck(H2Connection $connection, int $port): void
+{
+    $bigDataBytes = 0;
+    $completedBeforeWindowUpdate = [];
+    $windowUpdateSent = false;
+    $completed = [];
+
+    $connection->sendFrame(new H2Frame(
+        H2Frame::TYPE_HEADERS,
+        H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM,
+        H2_CHECK_STREAM_PRIMARY,
+        buildRequestHeaderBlock('GET', 'http', '127.0.0.1:' . $port, '/big?size=32768')
+    ));
+    $connection->sendFrame(new H2Frame(
+        H2Frame::TYPE_HEADERS,
+        H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM,
+        H2_CHECK_STREAM_SECONDARY,
+        buildRequestHeaderBlock('GET', 'http', '127.0.0.1:' . $port, '/small?id=3')
+    ));
+    $connection->sendFrame(new H2Frame(
+        H2Frame::TYPE_HEADERS,
+        H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM,
+        H2_CHECK_STREAM_TERTIARY,
+        buildRequestHeaderBlock('GET', 'http', '127.0.0.1:' . $port, '/small?id=5')
+    ));
+
+    while (count($completed) < 3) {
+        $frame = readUsefulFrame($connection);
+        if ($frame->type !== H2Frame::TYPE_DATA) {
+            continue;
+        }
+
+        if ($frame->streamId === H2_CHECK_STREAM_PRIMARY) {
+            $bigDataBytes += strlen($frame->payload);
+            if (!$windowUpdateSent && $bigDataBytes >= H2_CHECK_INITIAL_WINDOW) {
+                $connection->sendFrame(H2Frame::createWindowUpdate(0, 65535));
+                $connection->sendFrame(H2Frame::createWindowUpdate(H2_CHECK_STREAM_PRIMARY, 65535));
+                $windowUpdateSent = true;
+            }
+        }
+
+        if (($frame->flags & H2Frame::FLAG_END_STREAM) !== 0) {
+            $completed[$frame->streamId] = true;
+            if (!$windowUpdateSent) {
+                $completedBeforeWindowUpdate[$frame->streamId] = true;
+            }
+        }
+    }
+
+    ksort($completedBeforeWindowUpdate);
+    echo 'COMPLETED_BEFORE_WINDOW_UPDATE=' . json_encode(array_keys($completedBeforeWindowUpdate)) . PHP_EOL;
+    echo 'BIG_DATA_BYTES=' . $bigDataBytes . PHP_EOL;
+}
+
+function sendClientPrefaceAndSettings(Socket $socket, H2Connection $connection, ?int $initialWindowSize): void
+{
+    $socket->send(H2Connection::CLIENT_PREFACE);
+    $payload = '';
+    if ($initialWindowSize !== null) {
+        $payload = pack('nN', H2Connection::SETTINGS_INITIAL_WINDOW_SIZE, $initialWindowSize);
+    }
+
+    $connection->sendFrame(new H2Frame(H2Frame::TYPE_SETTINGS, 0, 0, $payload));
+}
+
+function sendRequestWithTrailers(H2Connection $connection, int $port): void
+{
+    $headers = buildRequestHeaderBlock('POST', 'http', '127.0.0.1:' . $port, '/echo');
+    $trailers = H2Headers::encodeTrailerHeaders(['x-client-trailer' => 'done']);
+
+    $connection->sendFrame(new H2Frame(
+        H2Frame::TYPE_HEADERS,
+        H2Frame::FLAG_END_HEADERS,
+        H2_CHECK_STREAM_PRIMARY,
+        $headers
+    ));
+    $connection->sendFrame(new H2Frame(
+        H2Frame::TYPE_DATA,
+        0,
+        H2_CHECK_STREAM_PRIMARY,
+        'payload-body'
+    ));
+    $connection->sendFrame(new H2Frame(
+        H2Frame::TYPE_HEADERS,
+        H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM,
+        H2_CHECK_STREAM_PRIMARY,
+        $trailers
+    ));
+}
+
+function sendResponseTrailerRequest(H2Connection $connection, int $port): void
+{
+    $connection->sendFrame(new H2Frame(
+        H2Frame::TYPE_HEADERS,
+        H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM,
+        H2_CHECK_STREAM_SECONDARY,
+        buildRequestHeaderBlock('GET', 'http', '127.0.0.1:' . $port, '/trailer')
+    ));
+}
+
+function readUsefulFrame(H2Connection $connection): H2Frame
+{
+    while (true) {
+        $frame = rawReadFrame($connection->getSocket());
+        if ($frame->type === H2Frame::TYPE_SETTINGS) {
+            if (($frame->flags & H2Frame::FLAG_ACK) === 0) {
+                $connection->sendFrame(new H2Frame(H2Frame::TYPE_SETTINGS, H2Frame::FLAG_ACK, 0, ''));
+            }
+            continue;
+        }
+        if ($frame->type === H2Frame::TYPE_PING) {
+            if (($frame->flags & H2Frame::FLAG_ACK) === 0) {
+                $connection->sendPingAck($frame->payload);
+            }
+            continue;
+        }
+
+        return $frame;
+    }
+}
+
+function readHeaderBlock(H2Connection $connection, H2Frame $firstFrame): string
+{
+    $buffer = $firstFrame->payload;
+    if (($firstFrame->flags & H2Frame::FLAG_END_HEADERS) !== 0) {
+        return $buffer;
+    }
+
+    while (true) {
+        $frame = readUsefulFrame($connection);
+        if ($frame->type !== H2Frame::TYPE_CONTINUATION || $frame->streamId !== $firstFrame->streamId) {
+            throw new RuntimeException('Unexpected frame while reading header block');
+        }
+        $buffer .= $frame->payload;
+        if (($frame->flags & H2Frame::FLAG_END_HEADERS) !== 0) {
+            return $buffer;
+        }
+    }
+}
+
+function rawReadFrame(Socket $socket): H2Frame
+{
+    $header = $socket->recvString(9, H2_CHECK_READ_TIMEOUT);
+    $length = (ord($header[0]) << 16) | (ord($header[1]) << 8) | ord($header[2]);
+    $payload = $length > 0 ? $socket->recvString($length, H2_CHECK_READ_TIMEOUT) : '';
+
+    return H2Frame::fromHeaderAndPayload($header, $payload);
+}
+
+function buildRequestHeaderBlock(string $method, string $scheme, string $authority, string $path): string
+{
+    $methodIndex = match ($method) {
+        'GET' => 2,
+        'POST' => 3,
+        default => throw new InvalidArgumentException('Unsupported method'),
+    };
+    $schemeIndex = match ($scheme) {
+        'http' => 6,
+        'https' => 7,
+        default => throw new InvalidArgumentException('Unsupported scheme'),
+    };
+
+    return encodeIndexedHeader($methodIndex)
+        . encodeIndexedHeader($schemeIndex)
+        . encodeIndexedNameLiteral(1, $authority)
+        . encodeIndexedNameLiteral(4, $path);
+}
+
+function encodeIndexedHeader(int $index): string
+{
+    return encodeInteger($index, 7, 0x80);
+}
+
+function encodeIndexedNameLiteral(int $nameIndex, string $value): string
+{
+    return encodeInteger($nameIndex, 6, 0x40) . encodeStringLiteral($value);
+}
+
+function encodeStringLiteral(string $value): string
+{
+    return encodeInteger(strlen($value), 7, 0) . $value;
+}
+
+function encodeInteger(int $value, int $prefixBits, int $prefixMask): string
+{
+    $maxPrefix = (1 << $prefixBits) - 1;
+    if ($value < $maxPrefix) {
+        return chr($prefixMask | $value);
+    }
+
+    $buffer = chr($prefixMask | $maxPrefix);
+    $value -= $maxPrefix;
+    while ($value >= 128) {
+        $buffer .= chr(($value % 128) + 128);
+        $value = intdiv($value, 128);
+    }
+
+    return $buffer . chr($value);
+}

--- a/examples/http_server/h2-runtime-server.php
+++ b/examples/http_server/h2-runtime-server.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+use Psr\Http\Message\ServerRequestInterface;
+use Swow\Coroutine;
+use Swow\Psr7\Psr7;
+use Swow\Psr7\Server\EventDriverConnectionHandler;
+use Swow\Psr7\Server\H2ResponseEnvelope;
+use Swow\Psr7\Server\H2ServerConnection;
+use Swow\Psr7\Server\Server;
+use Swow\Psr7\Server\ServerConnection;
+use Swow\SocketException;
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+require dirname(__DIR__, 2) . '/ext/tests/include/bootstrap.php';
+
+const H2_RUNTIME_BIG_SIZE = 262144;
+const H2_RUNTIME_MAX_CONNECTIONS = 64;
+const H2_RUNTIME_CERTIFICATE = __DIR__ . '/certs/localhost.pem';
+const H2_RUNTIME_CERTIFICATE_KEY = __DIR__ . '/certs/localhost-key.pem';
+
+$mode = $argv[1] ?? 'tls';
+$maxConnections = isset($argv[2]) ? (int) $argv[2] : H2_RUNTIME_MAX_CONNECTIONS;
+$host = $argv[3] ?? 'localhost';
+$x509Base = '/tmp/swow_h2_runtime_x509';
+
+$server = new Server();
+$server->bind($host, 9764)->listen();
+$port = $server->getSockPort();
+
+$tlsOptions = null;
+if ($mode === 'tls') {
+    $paths = null;
+    if (!is_file(H2_RUNTIME_CERTIFICATE) || !is_file(H2_RUNTIME_CERTIFICATE_KEY)) {
+        $paths = testX509Paths($x509Base);
+    }
+    $tlsOptions = [
+        'certificate' => $paths['localhost']['cert'] ?? H2_RUNTIME_CERTIFICATE,
+        'certificate_key' => $paths['localhost']['key'] ?? H2_RUNTIME_CERTIFICATE_KEY,
+        'verify_peer' => false,
+        'alpn_protocols' => 'h2,http/1.1',
+    ];
+}
+
+$handler = new EventDriverConnectionHandler(
+    connectionHandler: static function (ServerConnection|H2ServerConnection $connection): void {
+        if (!method_exists($connection, 'getNegotiatedAlpnProtocol')) {
+            return;
+        }
+
+        $protocol = $connection->getNegotiatedAlpnProtocol();
+        echo 'CONNECTION_ALPN=' . ($protocol ?? 'null') . PHP_EOL;
+    },
+    requestHandler: static function (ServerConnection|H2ServerConnection $connection, ServerRequestInterface $request): array|H2ResponseEnvelope {
+        $path = $request->getUri()->getPath();
+        $query = [];
+        parse_str($request->getUri()->getQuery(), $query);
+        $requestBody = (string) $request->getBody();
+        $trailers = $connection instanceof H2ServerConnection
+            ? H2ServerConnection::getRequestTrailers($request)
+            : [];
+
+        if ($path === '/health') {
+            return [
+                'status' => 200,
+                'headers' => ['content-type' => 'application/json'],
+                'body' => json_encode([
+                    'path' => $path,
+                    'protocol' => $request->getProtocolVersion(),
+                    'method' => $request->getMethod(),
+                ], JSON_UNESCAPED_UNICODE),
+            ];
+        }
+
+        if ($path === '/echo') {
+            return [
+                'status' => 200,
+                'headers' => ['content-type' => 'application/json'],
+                'body' => json_encode([
+                    'path' => $path,
+                    'protocol' => $request->getProtocolVersion(),
+                    'method' => $request->getMethod(),
+                    'body' => $requestBody,
+                    'trailers' => $trailers,
+                ], JSON_UNESCAPED_UNICODE),
+            ];
+        }
+
+        if ($path === '/small') {
+            $id = (string) ($query['id'] ?? 'none');
+            return [
+                'status' => 200,
+                'headers' => [
+                    'content-type' => 'text/plain',
+                    'x-small-id' => $id,
+                ],
+                'body' => 'small:' . $id,
+            ];
+        }
+
+        if ($path === '/big') {
+            $size = isset($query['size']) ? max(1, (int) $query['size']) : H2_RUNTIME_BIG_SIZE;
+            return [
+                'status' => 200,
+                'headers' => [
+                    'content-type' => 'text/plain',
+                    'x-big-size' => (string) $size,
+                ],
+                'body' => str_repeat('B', $size),
+            ];
+        }
+
+        if ($path === '/trailer') {
+            return H2ResponseEnvelope::from(
+                Psr7::createResponse(
+                    code: 200,
+                    headers: ['content-type' => 'text/plain'],
+                    body: 'with-trailer'
+                ),
+                ['x-trailer-status' => 'done']
+            );
+        }
+
+        if ($path === '/goaway') {
+            if ($connection instanceof H2ServerConnection) {
+                $connection->getConnection()->goAway(
+                    lastStreamId: $connection->getConnection()->getLastProcessedStreamId()
+                );
+            }
+
+            return [
+                'status' => 200,
+                'headers' => ['content-type' => 'text/plain'],
+                'body' => 'goaway',
+            ];
+        }
+
+        return [
+            'status' => 404,
+            'headers' => ['content-type' => 'text/plain'],
+            'body' => 'not-found',
+        ];
+    },
+    upgradeHandler: null,
+    messageHandler: null,
+    closeHandler: static function (): void {
+        echo "CONNECTION_CLOSED\n";
+    },
+    exceptionHandler: static function (ServerConnection|H2ServerConnection $connection, Throwable $throwable): void {
+        echo 'EXCEPTION=' . $throwable::class . ':' . $throwable->getMessage() . PHP_EOL;
+    },
+);
+
+echo 'MODE=' . $mode . PHP_EOL;
+echo 'HOST=' . $host . PHP_EOL;
+echo 'PORT=' . $port . PHP_EOL;
+
+$accepted = 0;
+while ($accepted < $maxConnections) {
+    try {
+        $connection = $server->acceptConnection();
+        Coroutine::run(static function () use ($connection, $handler, $mode, $tlsOptions): void {
+            if ($mode === 'tls') {
+                $connection->enableCrypto($tlsOptions);
+            }
+
+            $handler->handle($connection);
+        });
+        $accepted++;
+    } catch (SocketException $exception) {
+        echo 'SERVER_EXCEPTION=' . $exception->getMessage() . PHP_EOL;
+        break;
+    }
+}
+
+$server->close();

--- a/ext/deps/libcat/src/cat_ssl.c
+++ b/ext/deps/libcat/src/cat_ssl.c
@@ -389,7 +389,8 @@ CAT_API void cat_ssl_context_set_security_level(cat_ssl_context_t *context, int 
 static cat_bool_t cat_ssl_alpn_protos_parse(cat_string_t *alpn, const char *alpn_protocols)
 {
     size_t len;
-    size_t i, start = 0;
+    size_t read_offset = 0;
+    size_t write_offset = 0;
     cat_bool_t ret;
 
     len = strlen(alpn_protocols);
@@ -397,26 +398,54 @@ static cat_bool_t cat_ssl_alpn_protos_parse(cat_string_t *alpn, const char *alpn
         cat_update_last_error(CAT_EINVAL, "SSL alpn protocols too long");
         return cat_false;
     }
-    ret = cat_string_alloc(alpn, len);
+    ret = cat_string_alloc(alpn, len + 1);
 #if CAT_ALLOC_HANDLE_ERRORS
     if (unlikely(!ret)) {
         cat_update_last_error_of_syscall("Malloc for SSL alpn failed");
         return cat_false;
     }
 #endif
-    for (i = 0; i <= len; i++) {
-        if (i == len || alpn_protocols[i] == ',') {
-            if (i - start > 255) {
+
+    /* OpenSSL expects ALPN protocols in wire format:
+     * [len][proto][len][proto]..., not as a comma-separated string.
+     * The PHP-facing option stays human-friendly ("h2,http/1.1"), so we
+     * normalize it here before passing it into SSL_CTX_set_alpn_protos().
+     */
+    while (read_offset < len) {
+        size_t protocol_start = read_offset;
+        size_t protocol_length;
+
+        while (read_offset < len && alpn_protocols[read_offset] != ',') {
+            read_offset++;
+        }
+
+        protocol_length = read_offset - protocol_start;
+        if (protocol_length == 0 || protocol_length > 255) {
+            cat_string_close(alpn);
+            cat_update_last_error(CAT_EINVAL, "SSL alpn protocol length out of range");
+            return cat_false;
+        }
+
+        ((unsigned char *) alpn->value)[write_offset++] = (unsigned char) protocol_length;
+        memcpy(alpn->value + write_offset, alpn_protocols + protocol_start, protocol_length);
+        write_offset += protocol_length;
+
+        if (read_offset < len) {
+            if (alpn_protocols[read_offset] != ',') {
                 cat_string_close(alpn);
+                cat_update_last_error(CAT_EINVAL, "SSL alpn protocols must be comma separated");
                 return cat_false;
             }
-            ((unsigned char *) alpn->value)[start] = (unsigned char) (i - start);
-            start = i + 1;
-        } else {
-            alpn->value[i + 1] = alpn_protocols[i];
+
+            read_offset++;
+            if (read_offset == len) {
+                cat_string_close(alpn);
+                cat_update_last_error(CAT_EINVAL, "SSL alpn protocols must not end with a separator");
+                return cat_false;
+            }
         }
     }
-    alpn->length = len + 1;
+    alpn->length = write_offset;
 
     return ret;
 }
@@ -449,7 +478,12 @@ CAT_API cat_bool_t cas_ssl_context_set_alpn_protocols(cat_ssl_context_t *context
         return cat_false;
     }
     if (is_client) {
-        if (!SSL_CTX_set_alpn_protos(context->ctx, (unsigned char *) context->alpn.value, (unsigned int) context->alpn.length)) {
+        /* SSL_CTX_set_alpn_protos() returns 0 on success.
+         * Also note that the freshly parsed buffer lives in the local `alpn`
+         * variable at this point; `context->alpn` is updated only after the
+         * OpenSSL call succeeds.
+         */
+        if (SSL_CTX_set_alpn_protos(context->ctx, (unsigned char *) alpn.value, (unsigned int) alpn.length) != 0) {
             cat_ssl_update_last_error(CAT_ESSL, "SSL_CTX_set_alpn_protos() failed");
             cat_string_close(&alpn);
             return cat_false;

--- a/ext/src/swow_socket.c
+++ b/ext/src/swow_socket.c
@@ -266,6 +266,40 @@ static PHP_METHOD(Swow_Socket, getFd)
     RETURN_LONG((zend_long) cat_socket_get_fd(socket));
 }
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swow_Socket_getNegotiatedAlpnProtocol, 0, 0, IS_STRING, 1)
+ZEND_END_ARG_INFO()
+
+static PHP_METHOD(Swow_Socket, getNegotiatedAlpnProtocol)
+{
+    SWOW_SOCKET_GETTER(s_socket, socket);
+
+    ZEND_PARSE_PARAMETERS_NONE();
+
+#ifdef CAT_SSL_HAVE_TLS_ALPN
+    if (!cat_socket_is_available(socket) || socket->internal == NULL || socket->internal->ssl == NULL) {
+        RETURN_NULL();
+    }
+
+    do {
+        cat_ssl_t *ssl = socket->internal->ssl;
+        cat_ssl_connection_t *connection = ssl->connection;
+        const unsigned char *alpn_proto = NULL;
+        unsigned int alpn_proto_len = 0;
+
+        if (connection == NULL) {
+            break;
+        }
+
+        SSL_get0_alpn_selected(connection, &alpn_proto, &alpn_proto_len);
+        if (alpn_proto != NULL && alpn_proto_len > 0) {
+            RETURN_STRINGL((const char *) alpn_proto, alpn_proto_len);
+        }
+    } while (0);
+#endif
+
+    RETURN_NULL();
+}
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swow_Socket_typeSimplify, 0, 1, IS_LONG, 0)
     ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -625,6 +659,9 @@ static PHP_METHOD(Swow_Socket, enableCrypto)
         swow_hash_str_fetch_int(options_array, "security_level", &options.security_level);
 #endif
 #ifdef CAT_SSL_HAVE_TLS_ALPN
+        /* Keep the PHP option as a comma-separated string such as
+         * "h2,http/1.1". libcat converts it to the OpenSSL ALPN wire format.
+         */
         swow_hash_str_fetch_str(options_array, "alpn_protocols", &options.alpn_protocols);
 #endif
         swow_hash_str_fetch_str(options_array, "passphrase", &options.passphrase);
@@ -1735,6 +1772,7 @@ static const zend_function_entry swow_socket_methods[] = {
     PHP_ME(Swow_Socket, getTypeName,               arginfo_class_Swow_Socket_getTypeName,         ZEND_ACC_PUBLIC)
     PHP_ME(Swow_Socket, getSimpleTypeName,         arginfo_class_Swow_Socket_getSimpleTypeName,   ZEND_ACC_PUBLIC)
     PHP_ME(Swow_Socket, getFd,                     arginfo_class_Swow_Socket_getFd,               ZEND_ACC_PUBLIC)
+    PHP_ME(Swow_Socket, getNegotiatedAlpnProtocol, arginfo_class_Swow_Socket_getNegotiatedAlpnProtocol, ZEND_ACC_PUBLIC)
     PHP_ME(Swow_Socket, getDnsTimeout,             arginfo_class_Swow_Socket_getTimeout,          ZEND_ACC_PUBLIC)
     PHP_ME(Swow_Socket, getAcceptTimeout,          arginfo_class_Swow_Socket_getTimeout,          ZEND_ACC_PUBLIC)
     PHP_ME(Swow_Socket, getConnectTimeout,         arginfo_class_Swow_Socket_getTimeout,          ZEND_ACC_PUBLIC)

--- a/ext/tests/swow_socket/get_negotiated_alpn_protocol.phpt
+++ b/ext/tests/swow_socket/get_negotiated_alpn_protocol.phpt
@@ -1,0 +1,52 @@
+--TEST--
+swow_socket: getNegotiatedAlpnProtocol
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.php';
+skip_if(!Swow\Extension::isBuiltWith('openssl'), 'extension must be built with ssl');
+skip_if(!Swow\Extension::isBuiltWith('libcurl'), 'extension must be built with libcurl');
+skip_if(!defined('CURL_HTTP_VERSION_2_0'), 'curl must be built with HTTP/2 support');
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swow\Coroutine;
+use Swow\Socket;
+use Swow\Sync\WaitReference;
+
+$paths = testX509Paths(__DIR__ . '/getNegotiatedAlpnProtocol');
+
+$server = new Socket(Socket::TYPE_TCP);
+$server->bind('127.0.0.1', 0)->listen();
+$port = $server->getSockPort();
+$wr = new WaitReference();
+
+Coroutine::run(static function () use ($server, $paths, $wr): void {
+    $connection = $server->accept()->enableCrypto([
+        'certificate' => $paths['localhost']['cert'],
+        'certificate_key' => $paths['localhost']['key'],
+        'verify_peer' => false,
+        'alpn_protocols' => 'h2,http/1.1',
+    ]);
+
+    echo 'server:' . ($connection->getNegotiatedAlpnProtocol() ?? 'null') . PHP_EOL;
+    $connection->close();
+});
+
+$client = (new Socket(Socket::TYPE_TCP))->connect('127.0.0.1', $port);
+$client->enableCrypto([
+    'ca_file' => $paths['ca']['cert'],
+    'verify_peer' => true,
+    'peer_name' => 'localhost',
+    'alpn_protocols' => 'h2',
+]);
+echo 'client:' . ($client->getNegotiatedAlpnProtocol() ?? 'null') . PHP_EOL;
+$client->close();
+
+$wr::wait($wr);
+$server->close();
+?>
+--EXPECT--
+client:h2
+server:h2

--- a/lib/swow-library/docs/h2-alpn-bug-analysis.md
+++ b/lib/swow-library/docs/h2-alpn-bug-analysis.md
@@ -1,0 +1,175 @@
+# H2 ALPN Bug 分析
+
+## 1. 问题现象
+
+在真实 TLS 握手验证过程中，Swow socket client 开启 ALPN 时失败，报错如下：
+
+```text
+Swow\SocketException: Socket enable crypto failed, reason: SSL_CTX_set_alpn_protos() failed
+```
+
+这个问题会阻塞新加的 `Swow\Socket::getNegotiatedAlpnProtocol()` 在真实 client/server 握手中的验证，即使该 PHP 方法本身已经在运行时可见。
+
+## 2. 复现路径
+
+这个 bug 通过一条直接的 Swow TLS client/server 握手链路复现，配置如下：
+
+- server ALPN: `h2,http/1.1`
+- client ALPN: `h2`
+
+相关测试入口：
+
+- [get_negotiated_alpn_protocol.phpt](/Users/heping/PhpWorkSpace/swow-cloud/swow/ext/tests/swow_socket/get_negotiated_alpn_protocol.phpt#L25)
+
+关键配置位置：
+
+- server 侧带 ALPN 的 `enableCrypto()`：
+  - [get_negotiated_alpn_protocol.phpt](/Users/heping/PhpWorkSpace/swow-cloud/swow/ext/tests/swow_socket/get_negotiated_alpn_protocol.phpt#L26)
+- client 侧带 ALPN 的 `enableCrypto()`：
+  - [get_negotiated_alpn_protocol.phpt](/Users/heping/PhpWorkSpace/swow-cloud/swow/ext/tests/swow_socket/get_negotiated_alpn_protocol.phpt#L38)
+
+## 3. 根因分析
+
+### 3.1 ALPN wire format 编码错误
+
+PHP 层对外暴露的配置是人类可读的逗号分隔字符串：
+
+```text
+h2,http/1.1
+```
+
+OpenSSL **不能**直接接受这个格式。它要求的是带长度前缀的 wire format：
+
+```text
+[len]["h2"][len]["http/1.1"]
+```
+
+原来的 `cat_ssl_alpn_protos_parse()` 实现没有正确构造这个 buffer，同时在偏移和长度处理上也存在问题，可能生成无效输出。
+
+相关代码：
+
+- 解析入口：
+  - [cat_ssl.c](/Users/heping/PhpWorkSpace/swow-cloud/swow/ext/deps/libcat/src/cat_ssl.c#L389)
+- 修正后的编码循环：
+  - [cat_ssl.c](/Users/heping/PhpWorkSpace/swow-cloud/swow/ext/deps/libcat/src/cat_ssl.c#L409)
+
+### 3.2 OpenSSL 返回值语义判断反了
+
+`SSL_CTX_set_alpn_protos()` 的返回值语义是：
+
+- `0` 表示成功
+- 非 `0` 表示失败
+
+旧逻辑把 `0` 当成失败，所以即使 ALPN buffer 本身正确，也会被错误地报告为失败。
+
+相关代码：
+
+- 修正后的成功/失败判断：
+  - [cat_ssl.c](/Users/heping/PhpWorkSpace/swow-cloud/swow/ext/deps/libcat/src/cat_ssl.c#L455)
+
+### 3.3 client 路径使用了错误的缓冲区变量
+
+解析完成后，正确的编码结果存在局部变量 `alpn` 中，但 client 侧调用 OpenSSL 时，使用的是 `context->alpn`，而不是已经解析完成的局部值。
+
+这会导致握手代码把过期的或未正确初始化的 ALPN 数据传给 OpenSSL。
+
+相关代码：
+
+- 局部解析缓冲区创建位置：
+  - [cat_ssl.c](/Users/heping/PhpWorkSpace/swow-cloud/swow/ext/deps/libcat/src/cat_ssl.c#L447)
+- client 侧改为使用局部 `alpn` 的 OpenSSL 调用：
+  - [cat_ssl.c](/Users/heping/PhpWorkSpace/swow-cloud/swow/ext/deps/libcat/src/cat_ssl.c#L455)
+
+## 4. 修复说明
+
+### 4.1 修正 libcat 的 ALPN 解析逻辑
+
+修改位置：
+
+- [cat_ssl.c](/Users/heping/PhpWorkSpace/swow-cloud/swow/ext/deps/libcat/src/cat_ssl.c#L389)
+
+修复内容：
+
+1. 将逗号分隔的 ALPN 字符串正确转换成 OpenSSL 所需的 wire format。
+2. 拒绝空协议名、尾部分隔符以及长度超过 255 字节的协议名。
+3. 将正确编码后的长度写入 `alpn->length`。
+
+### 4.2 修正 client 侧 OpenSSL 调用的成功条件
+
+修改位置：
+
+- [cat_ssl.c](/Users/heping/PhpWorkSpace/swow-cloud/swow/ext/deps/libcat/src/cat_ssl.c#L452)
+
+修复内容：
+
+1. `SSL_CTX_set_alpn_protos()` 只有返回 `0` 时才视为成功。
+2. 直接把本地编码后的 `alpn` buffer 传给 OpenSSL。
+
+### 4.3 补充 PHP 层配置契约说明
+
+修改位置：
+
+- [swow_socket.c](/Users/heping/PhpWorkSpace/swow-cloud/swow/ext/src/swow_socket.c#L662)
+
+修复内容：
+
+1. 增加英文注释，明确 PHP 层仍然传逗号分隔字符串。
+2. 明确说明把它转换成 OpenSSL wire format 的责任在 libcat。
+
+## 5. 运行时验证结果
+
+修复并重新编译扩展后，下面这组真实 TLS/ALPN 矩阵已经通过：
+
+```text
+h2:client=h2
+h2:server=h2
+http1:client=http/1.1
+http1:server=http/1.1
+null:client=null
+null:server=null
+```
+
+这说明：
+
+1. `h2` 协商正常。
+2. `http/1.1` 协商正常。
+3. 不带 ALPN 的 TLS 握手会返回 `null`。
+
+同时也确认了新 getter 在运行时可见：
+
+- `method_exists("Swow\\Socket", "getNegotiatedAlpnProtocol") === true`
+
+## 6. 影响范围
+
+这个修复只影响 **显式配置了 `alpn_protocols` 的 TLS 连接**。
+
+它 **不会**改变：
+
+1. 非 TLS socket
+2. 未配置 ALPN 的 TLS socket
+3. negotiated ALPN 处理以外的 PHP 层 H2 路由逻辑
+
+## 7. 回归关注点
+
+后续如果继续改 TLS 或 OpenSSL 相关代码，至少要持续检查这些场景：
+
+1. `alpn_protocols => 'h2'`
+2. `alpn_protocols => 'h2,http/1.1'`
+3. `alpn_protocols => 'http/1.1'`
+4. 未配置 ALPN
+5. 非法值：
+   - 空字符串
+   - 尾部分隔符，例如 `h2,`
+   - 头部分隔符，例如 `,h2`
+   - 长度超过 255 字节的协议名
+
+## 8. 相关文件
+
+- getter 实现：
+  - [swow_socket.c](/Users/heping/PhpWorkSpace/swow-cloud/swow/ext/src/swow_socket.c#L269)
+- PHP 层 ALPN 选项透传：
+  - [swow_socket.c](/Users/heping/PhpWorkSpace/swow-cloud/swow/ext/src/swow_socket.c#L662)
+- ALPN 解析与 OpenSSL 接入：
+  - [cat_ssl.c](/Users/heping/PhpWorkSpace/swow-cloud/swow/ext/deps/libcat/src/cat_ssl.c#L389)
+- 运行时 PHPT：
+  - [get_negotiated_alpn_protocol.phpt](/Users/heping/PhpWorkSpace/swow-cloud/swow/ext/tests/swow_socket/get_negotiated_alpn_protocol.phpt#L25)

--- a/lib/swow-library/docs/h2-server-runtime-design.md
+++ b/lib/swow-library/docs/h2-server-runtime-design.md
@@ -1,0 +1,472 @@
+# H2 Server Runtime Design
+
+## 1. 背景与目标
+
+当前 Swow 的 HTTP 收发主链路仍基于 HTTP/1.x parser：
+
+- `ext/src/swow_http.c` 绑定 `cat_http_parser_*`，能力模型是文本 HTTP；
+- `lib/swow-library/src/Http/Protocol/ReceiverTrait.php` 负责 HTTP/1.x request/response 解析；
+- `lib/swow-library/src/Psr7/Server/ServerConnection.php` 直接继承 `Socket`，对外暴露的是 HTTP/1.x / WebSocket 语义。
+
+本设计的目标是：在 **不修改现有 C 层 HTTP/1.x parser**、**不破坏现有 HTTP/1.x API** 的前提下，为 `feature_h2` 提供一条独立的 PHP 层 HTTP/2 服务端实现路径。
+
+首版边界：
+
+1. 只做服务端，不做客户端；
+2. 优先支持 `TLS ALPN h2`，`h2c` 作为第二阶段；
+3. 先打通协议底座和最小请求/响应闭环；
+4. 高级能力先保留底座，不急于暴露业务 API。
+
+---
+
+## 2. 远端 `packages/h2` 功能清单
+
+上游参考：`php-standard-library/php-standard-library` 的 `packages/h2`。
+
+### 2.1 已确认的完整能力
+
+#### 连接与角色模型
+
+- `ClientConnection` / `ServerConnection`
+  - 分别提供 client/server 端连接对象；
+  - server 端显式校验 client preface。
+- `ConnectionInterface`
+  - 统一抽象初始化、读事件、发 headers/data、流控等待、`RST_STREAM`、`PING`、`GOAWAY`。
+- `Internal/StateMachine.php`
+  - 维护连接关闭状态、stream id 分配、last peer stream id、active stream 计数。
+
+#### 帧层
+
+- `Frame/*`
+  - 已实现 `DATA`、`HEADERS`、`CONTINUATION`、`SETTINGS`、`WINDOW_UPDATE`、`RST_STREAM`、`PING`、`GOAWAY`；
+  - 还实现了 `PUSH_PROMISE`、`PRIORITY`、`PRIORITY_UPDATE`、`ALTSVC`、`ORIGIN`。
+- `Frame/decode.php` / `Frame/encode.php`
+  - 提供二进制帧编码与解码。
+
+#### 头部与 HPACK
+
+- `Internal/HeaderBlockAssembler.php`
+  - 重组跨 `CONTINUATION` 的 header block。
+- `Internal/HeaderValidator.php`
+  - 校验 pseudo-header 顺序、重复、大小写、`CONNECT` / extended CONNECT 约束。
+- `packages/hpack`
+  - 上游单独提供 HPACK `Encoder` / `Decoder`。
+
+#### 状态机与流生命周期
+
+- `Internal/StreamTable.php` / `Internal/StreamEntry.php`
+  - 管理 stream 表、活动数、窗口初值、并发上限。
+- `StreamState.php`
+  - 覆盖 `idle/open/half-closed/reserved/closed`。
+- `StateMachine::receive*()`
+  - 负责帧分派、状态迁移、用户事件产出。
+
+#### 流控与可靠性
+
+- `Internal/FlowController.php`
+  - 分别管理 connection-level 和 stream-level send/receive window。
+- `ConnectionTrait::waitForSendWindow()`
+  - 支持等待窗口可用后再发。
+- `StateMachine::receiveDataRaw()`
+  - 消耗 receive window，并自动补 `WINDOW_UPDATE`。
+- `RateLimiter.php`
+  - 针对 `SETTINGS` / `PING` / `RST_STREAM` / `PRIORITY` / empty DATA 做速率限制。
+
+#### 事件模型
+
+- `Event/*`
+  - 已建模 `HeadersReceived`、`DataReceived`、`SettingsReceived`、`PingReceived`、`GoAwayReceived`、
+    `StreamReset`、`StreamClosed`、`WindowUpdated`；
+  - 还建模了 `PushPromiseReceived`、`PriorityUpdateReceived`、`AltSvcReceived`、`OriginReceived`。
+
+#### 性能与优化
+
+- `ConnectionTrait`
+  - 支持 write buffer 聚合写。
+- `Internal/BDPEstimator.php`
+  - 基于 `PING ACK` 和吞吐量估算接收窗口。
+
+### 2.2 需要保守看待的点
+
+1. 未在上游包目录中看到随包分发的 `tests/`；
+2. 因此不能把“存在类与方法”直接视为“已完成充分回归”；
+3. Swow 引入时必须重新建立自己的最小回归集。
+
+---
+
+## 3. Swow 差距分析与接入方案
+
+### 3.1 当前 Swow 现状
+
+#### 已具备能力
+
+- Socket/TLS 基础能力已具备；
+- `enableCrypto()` 已暴露 `alpn_protocols` 选项；
+- `ext/tests/swow_socket/ssl_alpn.phpt` 已证明 Swow TLS 通道可协商到 `h2`；
+- `UpgradeType::fromString()` 已能识别 `h2c`。
+
+#### 尚不具备能力
+
+- 没有 HTTP/2 二进制帧 parser / encoder；
+- 没有 HPACK 编解码；
+- 没有 HTTP/2 stream 状态机与流控；
+- `Psr7\Server\ServerConnection` 只适配 HTTP/1.x 单请求收发，不适合直接承载 H2 多路复用。
+
+### 3.2 接入原则
+
+1. **不改 C 层 HTTP/1.x parser**
+   - H2 是二进制 framing，不应强塞进现有 `llhttp` 语义。
+2. **不破坏现有 HTTP/1.x API**
+   - `Client` / `ServerConnection` 现有签名不动。
+3. **PHP 层独立实现 H2 server runtime**
+   - 直接基于 `Swow\Socket` 收发 H2 二进制帧。
+4. **协议层与 Psr7 适配层分层**
+   - 协议底座只做连接、流、帧、事件；
+   - Psr7 层只负责把 stream 映射成 request/response。
+
+### 3.3 首版建议分层
+
+#### 协议层
+
+新增独立 H2 运行时模块，职责仅包括：
+
+- 读取 client preface；
+- 发送/接收 `SETTINGS`；
+- 解析 `HEADERS/CONTINUATION/DATA/WINDOW_UPDATE/RST_STREAM/PING/GOAWAY`；
+- 维护 stream state 与基础流控；
+- 向上层抛出 stream 级事件。
+
+#### Psr7 适配层
+
+新增独立 H2 server connection 适配对象，职责包括：
+
+- 从 H2 headers 构造 `ServerRequestInterface`；
+- 把响应拆成 `:status + headers + data`；
+- 管理单个 stream 的响应发送与关闭；
+- 保持与现有 HTTP/1.x `ServerConnection` 并行，而非替换。
+
+#### 连接入口
+
+- `TLS ALPN h2`
+  - 作为首版默认入口；
+  - 在握手后分流到 H2 连接实现。
+- `h2c`
+  - 第二阶段补；
+  - 不能影响当前 HTTP/1.x upgrade 路径稳定性。
+
+### 3.4 首版对外暴露能力
+
+首版建议只承诺：
+
+1. 单连接初始化与 preface/SETTINGS 协商；
+2. 基础 request HEADERS 读取；
+3. 基础 response HEADERS + DATA 发送；
+4. 基础 `WINDOW_UPDATE` / `PING` / `RST_STREAM` / `GOAWAY`；
+5. 多 stream 并发不串流。
+
+首版不对业务 API 承诺：
+
+- server push；
+- `ORIGIN`；
+- `ALTSVC`；
+- `PRIORITY` / `PRIORITY_UPDATE`；
+- extended CONNECT。
+
+这些能力可以在协议底座中保留扩展位，但不进入首版公开语义。
+
+---
+
+## 4. 待确认问题
+
+### 4.1 依赖策略
+
+问题：HPACK 与状态机是直接移植上游，还是按 Swow 风格重写最小子集？
+
+已知事实：
+
+- 上游 H2 依赖 `packages/hpack`；
+- 上游连接实现还依赖 `Psl\Async` / `Revolt\EventLoop` 风格的取消与挂起。
+
+影响：
+
+- 直接移植快，但会引入额外风格与依赖面；
+- 重写更贴合 Swow，但前期成本更高。
+
+默认建议：
+
+- **状态机与帧模型可参考上游实现，异步等待语义改写为 Swow 风格；**
+- **HPACK 可优先采用“内聚移植”而非在公共 API 中散落外部依赖。**
+
+### 4.2 `h2c` 交付时机
+
+问题：`h2c` 是否必须和 `ALPN h2` 同批交付？
+
+已知事实：
+
+- 本地已有 `UpgradeType::UPGRADE_TYPE_H2C`；
+- 但没有现成 H2 明文升级实现。
+
+默认建议：
+
+- 首版先交付 `ALPN h2`；
+- `h2c` 放到第二阶段，避免把首版入口复杂度拉高。
+
+### 4.3 入口形态
+
+问题：H2 是新增独立 `H2ServerConnection`，还是扩展现有 server factory 分流？
+
+默认建议：
+
+- 两者都要做，但顺序上是：
+  1. 先新增独立 `H2ServerConnection`；
+  2. 再通过 factory/accept 路径分流接入。
+
+原因：
+
+- 先做独立对象更容易测试；
+- 避免早期把协议分流逻辑和协议本体耦在一起。
+
+### 4.4 高级能力暴露边界
+
+问题：`server push / origin / alt-svc` 是否只保留底座，不暴露对外 API？
+
+默认建议：
+
+- 是。首版先不暴露业务接口。
+
+原因：
+
+- 这些能力不是最小可用服务端闭环所必需；
+- 过早暴露只会扩大测试与兼容面。
+
+---
+
+## 5. 优化建议
+
+### 5.1 先做最小可用协议子集
+
+不要一开始就把上游全部帧类型和事件全部接到 Swow 对外 API。
+
+首批必须实现：
+
+- preface；
+- `SETTINGS`；
+- `HEADERS/CONTINUATION`；
+- `DATA`；
+- `WINDOW_UPDATE`；
+- `RST_STREAM`；
+- `PING`；
+- `GOAWAY`；
+- 基础 header 校验。
+
+### 5.2 成熟终版判定标准
+
+“完全成熟版 H2 版本”在本仓库中的含义，不是“代码大部分已经存在”，而是同时满足下面 4 类条件：
+
+#### A. 协议能力完整
+
+必须满足：
+
+1. TLS 连接可基于 ALPN 自动分流到 `h2` / `http/1.1`；
+2. 明文连接可通过 `h2c` 正常升级；
+3. request / response 均支持：
+   - `HEADERS/CONTINUATION`
+   - `DATA`
+   - `SETTINGS`
+   - `WINDOW_UPDATE`
+   - `PING`
+   - `RST_STREAM`
+   - `GOAWAY`
+   - request trailer
+   - response trailer
+4. HPACK 至少对真实客户端常见场景可用：
+   - Huffman 解码可用；
+   - dynamic table 可跨多个 header block 正常演进；
+   - table size update 可正常处理；
+5. 对服务端明确不支持的 frame / 行为，必须显式报协议错误，而不是静默忽略或退化。
+
+#### B. 调度与流控成熟
+
+必须满足：
+
+1. 多个 stream 并发交错时：
+   - 不串流；
+   - 不丢帧；
+   - 不死循环；
+   - 不因某个 stream 的窗口阻塞而长期饿死其他 stream；
+2. 请求读取、body 读取、trailer 读取、响应发送、窗口等待，必须共享同一套一致的调度语义；
+3. 发送窗口耗尽后，能等待 `WINDOW_UPDATE` 恢复并继续发送；
+4. `GOAWAY`、`RST_STREAM`、`WINDOW_UPDATE` 在等待窗口和多 stream 交错场景下行为稳定；
+5. pending / defer 队列必须具备明确的控制帧优先与 stream 间公平推进规则。
+
+#### C. 状态机与错误语义完整
+
+必须满足：
+
+1. 关键 stream 状态至少覆盖：
+   - `idle`
+   - `open`
+   - `half_closed_remote`
+   - `half_closed_local`
+   - `closed`
+2. frame/state 组合必须具备明确语义：
+   - 合法时继续推进；
+   - 非法时明确区分 connection error / stream error；
+3. 旧 stream、已关闭 stream、`GOAWAY` 后新 stream、`RST_STREAM` 后重入，行为必须一致；
+4. 不允许依赖 silent fallback 或模糊行为来“让它继续跑”。
+
+#### D. 真实运行验证通过
+
+必须满足：
+
+1. 新扩展编译后，`Swow\Socket::getNegotiatedAlpnProtocol()` 在真实 TLS 连接上返回预期值；
+2. 同一个 server 下，TLS+h2、TLS+HTTP/1.1、`h2c` 三条入口都能正常工作；
+3. `EventDriver`、`Server::handleH2Connection()`、直连 H2 路径，行为一致；
+4. 真实客户端（至少 curl / 业务客户端）下，大 header、大 body、小窗口、多 stream、trailer 组合场景稳定。
+
+只有 A/B/C/D 四类都满足，才可把该实现称为“完全成熟版 H2 版本”。
+
+### 5.3 当前实现与成熟终版的关系
+
+当前实现已经满足：
+
+- H2 服务端主体链路已经存在；
+- TLS 自动 H2 入口、`h2c`、request/response、trailer、流控、`GOAWAY/RST_STREAM`、HPACK 核心路径均已接入；
+- 自动化回归已能覆盖大部分协议与 server 入口路径；
+- 当前 H2/server 回归基线为：
+  - `Tests: 174`
+  - `Assertions: 513`
+  - `Skipped: 2`（当前环境 bind/listen 限制）
+
+当前实现仍不应在文档里直接宣称为“完全成熟终版”，原因只有两类：
+
+1. **代码成熟度边界**
+   - 多 stream 调度已明显成熟，但还不是一个完全独立、可证明公平性的完整 scheduler 框架；
+   - RFC 状态矩阵已覆盖很多关键组合，但还不是“所有 frame/state 组合全覆盖”。
+2. **真实运行验证边界**
+   - 新扩展 getter、TLS/ALPN 自动分流、真实 `h2c`、真实客户端长期交互，还需要本地实跑验证。
+
+因此当前更准确的定位是：
+
+- **高完整度 H2 服务端候选版本**
+- **可进入本地真实流量验证**
+- **接近可上线候选版**
+
+而不是文档意义上的“完全成熟终版”。
+
+### 5.4 本地验证重点清单
+
+在进入生产前，至少需要完成下面的本地验证：
+
+#### TLS / ALPN
+
+- `getNegotiatedAlpnProtocol()`：
+  - TLS+h2 返回 `h2`
+  - TLS+HTTP/1.1 返回 `http/1.1`
+  - 非 TLS / 未协商返回 `null`
+- 同一 server 下 H2 和 HTTP/1.1 混跑不互相污染
+
+#### h2c
+
+- 正常升级
+- 缺失 `HTTP2-Settings`
+- 非法 `HTTP2-Settings`
+- 升级请求带 body
+- 升级后继续多个 stream
+
+#### trailer
+
+- request trailer 可读
+- response trailer 可发
+- trailer 含 pseudo-header 明确失败
+
+#### 多 stream + 小窗口
+
+- 大响应发送到一半窗口耗尽
+- 期间到来 stream `3/5` 新请求
+- 连续 `WINDOW_UPDATE` 恢复
+- 期间混入 `RST_STREAM`
+- 期间混入 `GOAWAY`
+- 期间混入 `HEADERS + CONTINUATION`
+
+#### 状态机边界
+
+- even stream / `stream 0` 的 request 类帧
+- 已关闭 stream 再收 `DATA/HEADERS/CONTINUATION/WINDOW_UPDATE`
+- `GOAWAY(lastStreamId)` 后旧 stream 收尾、新 stream 拒绝
+- `RST_STREAM` 后同 stream 再次收帧
+
+### 5.2 把协议状态与 Psr7 对象解耦
+
+不要让 `ServerRequest` / `Response` 直接持有协议底层可变状态。
+
+推荐做法：
+
+- 协议层维护 stream table；
+- Psr7 层只拿只读请求视图和受控响应写口。
+
+### 5.3 明确首版错误暴露
+
+不要做 silent fallback，不要自动降级成 HTTP/1.1。
+
+推荐做法：
+
+- preface 错误：直接失败并关闭连接；
+- 帧级协议错误：显式 `GOAWAY`；
+- stream 级错误：显式 `RST_STREAM`；
+- 流控错误：直接暴露异常并带 stream id / window 上下文。
+
+### 5.4 先建立 Swow 自己的回归集
+
+建议至少覆盖：
+
+1. `TLS ALPN h2` 协商成功；
+2. preface + 初始 `SETTINGS`；
+3. 单 stream request/response；
+4. 双 stream 并发；
+5. 大 body 分片与窗口回补；
+6. 非法 pseudo-header；
+7. `CONTINUATION` 被打断；
+8. `WINDOW_UPDATE` overflow；
+9. `GOAWAY` 后拒绝新 stream。
+
+---
+
+## 6. 首版实施建议
+
+建议按以下顺序推进：
+
+1. 先新增 H2 分析文档；
+2. 再做协议底座最小骨架；
+3. 再做独立 H2 server connection；
+4. 最后再把 server accept 路径接入协议分流；
+5. `h2c` 与高级能力后置。
+
+这样可以保证每一步都能独立验证，并且不破坏现有 HTTP/1.x 路径。
+
+---
+
+## 7. 证据索引
+
+### 本地仓库
+
+- `ext/src/swow_http.c`
+- `ext/src/swow_socket.c`
+- `ext/tests/swow_socket/ssl_alpn.phpt`
+- `lib/swow-library/src/Http/Protocol/ReceiverTrait.php`
+- `lib/swow-library/src/Psr7/Server/Server.php`
+- `lib/swow-library/src/Psr7/Server/ServerConnection.php`
+- `lib/swow-library/src/Psr7/Message/UpgradeType.php`
+
+### 上游参考仓库
+
+- `packages/h2/src/Psl/H2/ConnectionInterface.php`
+- `packages/h2/src/Psl/H2/ClientConnection.php`
+- `packages/h2/src/Psl/H2/ServerConnection.php`
+- `packages/h2/src/Psl/H2/Internal/ConnectionTrait.php`
+- `packages/h2/src/Psl/H2/Internal/StateMachine.php`
+- `packages/h2/src/Psl/H2/Internal/FlowController.php`
+- `packages/h2/src/Psl/H2/Internal/HeaderValidator.php`
+- `packages/h2/src/Psl/H2/RateLimiter.php`
+- `packages/hpack/src/Psl/HPACK/Encoder.php`
+- `packages/hpack/src/Psl/HPACK/Decoder.php`

--- a/lib/swow-library/docs/h2-validation-matrix.md
+++ b/lib/swow-library/docs/h2-validation-matrix.md
@@ -1,0 +1,106 @@
+# H2 验证矩阵
+
+## 1. 已真实跑通
+
+以下场景已经通过真实请求验证：
+
+1. TLS + ALPN `h2`
+2. TLS + ALPN `http/1.1`
+3. `h2c` upgrade 成功
+4. `h2c` upgrade 失败
+   - 缺失 `HTTP2-Settings`
+   - 非法 `HTTP2-Settings`
+5. `h2c` upgrade 请求带 body
+6. request trailer
+7. response trailer
+8. 多 stream 并发请求
+9. 小窗口下大响应恢复发送
+
+## 2. 使用的脚本
+
+### 2.1 运行时服务脚本
+
+- [h2-runtime-server.php](/Users/heping/PhpWorkSpace/swow-cloud/swow/examples/http_server/h2-runtime-server.php)
+
+支持：
+
+- `tls` 模式
+- `clear` 模式
+
+提供接口：
+
+- `/health`
+- `/echo`
+- `/small`
+- `/big`
+- `/trailer`
+- `/goaway`
+
+### 2.2 原始 H2 检查脚本
+
+- [h2-runtime-checks.php](/Users/heping/PhpWorkSpace/swow-cloud/swow/examples/http_server/h2-runtime-checks.php)
+
+支持模式：
+
+1. `trailers`
+2. `multistream`
+
+## 3. 推荐验证顺序
+
+### 3.1 TLS
+
+启动：
+
+```bash
+php -d extension=swow examples/http_server/h2-runtime-server.php tls 50
+```
+
+验证：
+
+```bash
+curl -skv --http2 https://127.0.0.1:PORT/health
+curl -skv --http1.1 https://127.0.0.1:PORT/health
+```
+
+### 3.2 h2c
+
+启动：
+
+```bash
+php -d extension=swow examples/http_server/h2-runtime-server.php clear 50
+```
+
+验证：
+
+```bash
+curl -sv --http1.1 http://127.0.0.1:PORT/health
+curl -sv --http2 http://127.0.0.1:PORT/health
+curl -sv --http2-prior-knowledge http://127.0.0.1:PORT/health
+```
+
+### 3.3 trailer 与多 stream
+
+```bash
+php -d extension=swow examples/http_server/h2-runtime-checks.php trailers PORT
+php -d extension=swow examples/http_server/h2-runtime-checks.php multistream PORT
+```
+
+## 4. 推荐继续关注的边界
+
+1. `GOAWAY(lastStreamId)` 后旧 stream 收尾
+2. `RST_STREAM` 在等待窗口恢复期间打断发送
+3. `HEADERS + CONTINUATION` 被延迟后恢复
+4. H2 preface 分包到达
+5. even stream / `stream 0` 的 request 类帧
+
+## 5. 当前结论
+
+当前 H2 代码已经具备：
+
+1. TLS + ALPN 自动分流
+2. `h2c` upgrade
+3. request / response trailer
+4. 多 stream 请求
+5. 小窗口恢复发送
+
+如果后续继续回归，优先复用上面的两个脚本，而不是再临时拼装测试入口。

--- a/lib/swow-library/src/Http/Protocol/H2Connection.php
+++ b/lib/swow-library/src/Http/Protocol/H2Connection.php
@@ -1,0 +1,1035 @@
+<?php
+
+/**
+ * This file is part of Swow
+ *
+ * @link    https://github.com/swow/swow
+ * @contact twosee <twosee@php.net>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code
+ */
+
+declare(strict_types=1);
+
+namespace Swow\Http\Protocol;
+
+use RuntimeException;
+use Swow\Buffer;
+use Swow\Socket;
+use Swow\SocketException;
+use Throwable;
+
+use function pack;
+use function strlen;
+use function substr;
+use function unpack;
+
+class H2Connection
+{
+    public const CLIENT_PREFACE = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+    public const DEFAULT_INITIAL_WINDOW_SIZE = 65_535;
+    public const DEFAULT_WINDOW_UPDATE_THRESHOLD = 32_768;
+    public const SETTINGS_INITIAL_WINDOW_SIZE = 0x4;
+    public const SETTINGS_MAX_FRAME_SIZE = 0x5;
+    public const MIN_MAX_FRAME_SIZE = 16_384;
+    public const MAX_MAX_FRAME_SIZE = 16_777_215;
+    public const STREAM_STATE_OPEN = 'open';
+    public const STREAM_STATE_HALF_CLOSED_REMOTE = 'half_closed_remote';
+    public const STREAM_STATE_HALF_CLOSED_LOCAL = 'half_closed_local';
+    public const STREAM_STATE_CLOSED = 'closed';
+
+    protected Buffer $buffer;
+
+    protected int $bufferedLength = 0;
+
+    protected int $localMaxFrameSize = H2Frame::DEFAULT_MAX_FRAME_SIZE;
+
+    protected int $streamInitialWindowSize = self::DEFAULT_INITIAL_WINDOW_SIZE;
+
+    protected int $streamSendInitialWindowSize = self::DEFAULT_INITIAL_WINDOW_SIZE;
+
+    protected int $connectionReceiveWindow = self::DEFAULT_INITIAL_WINDOW_SIZE;
+
+    protected int $connectionSendWindow = self::DEFAULT_INITIAL_WINDOW_SIZE;
+
+    /** @var array<int, int> */
+    protected array $streamReceiveWindows = [];
+
+    /** @var array<int, int> */
+    protected array $streamSendWindows = [];
+
+    /** @var array<int, int> */
+    protected array $connectionBytesConsumed = [];
+
+    /** @var array<int, int> */
+    protected array $streamBytesConsumed = [];
+
+    protected int $lastProcessedStreamId = 0;
+
+    protected int $lastAllowedStreamId = H2Frame::MAX_STREAM_ID;
+
+    protected bool $goAwaySent = false;
+
+    protected bool $goAwayReceived = false;
+
+    /** @var array<int, true> */
+    protected array $closedStreams = [];
+
+    /** @var array<int, self::STREAM_STATE_*> */
+    protected array $streamStates = [];
+
+    protected H2PendingFrameQueue $pendingFrames;
+
+    protected H2FrameScheduler $scheduler;
+
+    protected ?int $activeHeaderBlockStreamId = null;
+
+    protected bool $initialized = false;
+
+    public function __construct(
+        protected Socket $socket,
+        protected int $bufferSize = 65_536,
+    ) {
+        $this->buffer = new Buffer($bufferSize);
+        $this->pendingFrames = new H2PendingFrameQueue();
+        $this->scheduler = new H2FrameScheduler($this->pendingFrames, $this->isSendWindowControlFrame(...));
+    }
+
+    public function getSocket(): Socket
+    {
+        return $this->socket;
+    }
+
+    public function isInitialized(): bool
+    {
+        return $this->initialized;
+    }
+
+    public function getLocalMaxFrameSize(): int
+    {
+        return $this->localMaxFrameSize;
+    }
+
+    public function getLastProcessedStreamId(): int
+    {
+        return $this->lastProcessedStreamId;
+    }
+
+    public function getLastAllowedStreamId(): int
+    {
+        return $this->lastAllowedStreamId;
+    }
+
+    public function hasSentGoAway(): bool
+    {
+        return $this->goAwaySent;
+    }
+
+    public function hasReceivedGoAway(): bool
+    {
+        return $this->goAwayReceived;
+    }
+
+    public function isStreamClosed(int $streamId): bool
+    {
+        return isset($this->closedStreams[$streamId]);
+    }
+
+    public function getStreamState(int $streamId): string|null
+    {
+        return $this->streamStates[$streamId] ?? null;
+    }
+
+    public function getConnectionSendWindow(): int
+    {
+        return $this->connectionSendWindow;
+    }
+
+    public function getStreamSendWindow(int $streamId): int
+    {
+        return $this->streamSendWindows[$streamId] ?? $this->streamSendInitialWindowSize;
+    }
+
+    public function getAvailableSendWindow(int $streamId): int
+    {
+        return min($this->connectionSendWindow, $this->getStreamSendWindow($streamId));
+    }
+
+    public function consumeSendWindow(int $streamId, int $bytes): void
+    {
+        if ($bytes === 0) {
+            return;
+        }
+
+        if ($this->connectionSendWindow < $bytes) {
+            throw H2Exception::forConnectionError(
+                'Connection send window exhausted',
+                H2Exception::ERROR_FLOW_CONTROL_ERROR
+            );
+        }
+
+        $streamWindow = $this->getStreamSendWindow($streamId);
+        if ($streamWindow < $bytes) {
+            throw H2Exception::forStreamError(
+                $streamId,
+                'Stream send window exhausted',
+                H2Exception::ERROR_FLOW_CONTROL_ERROR
+            );
+        }
+
+        $this->connectionSendWindow -= $bytes;
+        $this->streamSendWindows[$streamId] = $streamWindow - $bytes;
+    }
+
+    public function readClientPreface(?int $timeout = null): void
+    {
+        $needed = strlen(self::CLIENT_PREFACE);
+        $preface = $this->readBytes($needed, $timeout);
+
+        if ($preface !== self::CLIENT_PREFACE) {
+            throw H2Exception::forConnectionError('Invalid client connection preface');
+        }
+    }
+
+    public function initialize(?int $timeout = null, array $settings = []): void
+    {
+        $this->sendSettings($settings, $timeout);
+        $this->initialized = true;
+    }
+
+    public function initializeForUpgrade(?int $timeout = null, array $settings = [], string $peerSettingsPayload = ''): void
+    {
+        if ($peerSettingsPayload !== '') {
+            $this->applySettingsPayload($peerSettingsPayload);
+        }
+
+        $this->sendSettings($settings, $timeout);
+        if ($peerSettingsPayload !== '') {
+            $this->sendSettings(timeout: $timeout, ack: true);
+        }
+        $this->initialized = true;
+    }
+
+    public function readFrame(?int $timeout = null): H2Frame
+    {
+        $header = $this->readBytes(H2Frame::HEADER_LENGTH, $timeout);
+        $metadata = H2Frame::decodeHeader($header);
+
+        if ($metadata['length'] > $this->localMaxFrameSize) {
+            throw H2Exception::forConnectionError(
+                'Received frame larger than local max frame size',
+                H2Exception::ERROR_FRAME_SIZE_ERROR
+            );
+        }
+
+        $payload = $this->readBytes($metadata['length'], $timeout);
+
+        return $this->validateFrame(new H2Frame(
+            $metadata['type'],
+            $metadata['flags'],
+            $metadata['streamId'],
+            $payload
+        ));
+    }
+
+    public function waitForSendWindow(int $streamId, int $minimum = 1, ?int $timeout = null): void
+    {
+        while ($this->getAvailableSendWindow($streamId) < $minimum) {
+            try {
+                $frame = $this->takePendingControlFrame() ?? $this->readFrame($timeout);
+            } catch (Throwable $exception) {
+                if ($this->connectionSendWindow === 0) {
+                    throw H2Exception::forConnectionError(
+                        'Connection send window exhausted',
+                        H2Exception::ERROR_FLOW_CONTROL_ERROR,
+                        $exception
+                    );
+                }
+
+                if ($this->getStreamSendWindow($streamId) === 0) {
+                    throw H2Exception::forStreamError(
+                        $streamId,
+                        'Stream send window exhausted',
+                        H2Exception::ERROR_FLOW_CONTROL_ERROR,
+                        $exception
+                    );
+                }
+
+                throw $exception;
+            }
+
+            if ($this->isSendWindowControlFrame($frame)) {
+                $this->pumpControlFrame($frame, $timeout);
+                $this->assertCanSendOnStream($streamId);
+                continue;
+            }
+
+            $this->deferFrame($frame);
+        }
+    }
+
+    public function validateFrame(H2Frame $frame): H2Frame
+    {
+        return match ($frame->type) {
+            H2Frame::TYPE_SETTINGS => $this->validateSettingsFrame($frame),
+            H2Frame::TYPE_PING => $this->validatePingFrame($frame),
+            H2Frame::TYPE_GOAWAY => $this->validateGoAwayFrame($frame),
+            H2Frame::TYPE_WINDOW_UPDATE => $this->validateWindowUpdateFrame($frame),
+            H2Frame::TYPE_RST_STREAM => $this->validateRstStreamFrame($frame),
+            H2Frame::TYPE_PRIORITY => $this->validatePriorityFrame($frame),
+            H2Frame::TYPE_PUSH_PROMISE => $this->validatePushPromiseFrame($frame),
+            default => $this->validateOpenStreamFrame($frame),
+        };
+    }
+
+    public function readHeaderBlock(?int $timeout = null): H2HeaderBlock
+    {
+        $headerBlock = $this->readHeaderBlockOrNull($timeout);
+        if (!$headerBlock instanceof H2HeaderBlock) {
+            throw H2Exception::forConnectionError('No more request streams are allowed on this connection');
+        }
+
+        return $headerBlock;
+    }
+
+    public function readHeaderBlockOrNull(?int $timeout = null): ?H2HeaderBlock
+    {
+        $frame = $this->readRequestStartFrame($timeout);
+        if (!$frame instanceof H2Frame) {
+            return null;
+        }
+
+        $this->assertCanAcceptRequestStream($frame->streamId);
+
+        if ($frame->payload === '') {
+            throw H2Exception::forConnectionError('HEADERS frame payload must not be empty');
+        }
+
+        $headerBlock = new H2HeaderBlock($frame->streamId);
+        $headerBlock->append($frame);
+        $this->activeHeaderBlockStreamId = $frame->streamId;
+        try {
+            while (!$headerBlock->isCompleted()) {
+                $continuation = $this->nextRelevantFrameForStream($frame->streamId, $timeout);
+                $headerBlock->append($continuation);
+            }
+        } finally {
+            $this->activeHeaderBlockStreamId = null;
+        }
+
+        $this->noteRemoteStreamOpened($frame->streamId, ($headerBlock->getFlags() & H2Frame::FLAG_END_STREAM) !== 0);
+        $this->markRequestStreamProcessed($frame->streamId);
+
+        return $headerBlock;
+    }
+
+    public function readRequestStartFrame(?int $timeout = null): ?H2Frame
+    {
+        return $this->scheduler->nextRequestStartFrame(
+            $this->readFrame(...),
+            $this->pumpControlFrame(...),
+            $this->canAcceptNewRequests(...),
+            $this->isGracefulRequestStartTermination(...),
+            $timeout
+        );
+    }
+
+    public function canAcceptNewRequests(): bool
+    {
+        return !$this->goAwayReceived || $this->lastProcessedStreamId < $this->lastAllowedStreamId;
+    }
+
+    public function readRequestBody(int $streamId, ?int $timeout = null): string
+    {
+        return $this->readRequestBodyWithTrailers($streamId, $timeout)['body'];
+    }
+
+    /**
+     * @return array{body: string, trailers: H2HeaderBlock|null}
+     */
+    public function readRequestBodyWithTrailers(int $streamId, ?int $timeout = null): array
+    {
+        if ($streamId < 1) {
+            throw H2Exception::forConnectionError('Request body stream ID must be positive');
+        }
+
+        $this->assertCanReceiveDataOnStream($streamId);
+        $this->streamReceiveWindows[$streamId] ??= $this->streamInitialWindowSize;
+        $this->connectionBytesConsumed[$streamId] ??= 0;
+        $this->streamBytesConsumed[$streamId] ??= 0;
+
+        $body = '';
+        while (true) {
+            $frame = $this->nextRelevantFrameForStream($streamId, $timeout);
+            if ($this->isSendWindowControlFrame($frame)) {
+                $this->pumpControlFrame($frame, $timeout);
+                $this->assertCanReceiveDataOnStream($streamId);
+                continue;
+            }
+
+            if ($frame->type === H2Frame::TYPE_DATA) {
+                $this->consumeReceiveWindow($streamId, strlen($frame->payload));
+                $body .= $frame->payload;
+                if (($frame->flags & H2Frame::FLAG_END_STREAM) !== 0) {
+                    $this->noteRemoteStreamEnded($streamId);
+                    return ['body' => $body, 'trailers' => null];
+                }
+
+                continue;
+            }
+
+            if ($frame->type === H2Frame::TYPE_HEADERS) {
+                $trailerBlock = $this->readTrailerHeaderBlock($frame, $timeout);
+                $this->noteRemoteStreamEnded($streamId);
+                return ['body' => $body, 'trailers' => $trailerBlock];
+            }
+
+            throw H2Exception::forConnectionError('Expected DATA or trailing HEADERS frame while reading request body');
+        }
+    }
+
+    public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+    {
+        try {
+            $this->socket->send($frame->encode(), timeout: $timeout);
+        } catch (SocketException $exception) {
+            throw H2Exception::forConnectionError(
+                'Failed to send H2 frame: ' . $exception->getMessage(),
+                H2Exception::ERROR_INTERNAL_ERROR,
+                $exception
+            );
+        }
+    }
+
+    public function sendSettings(array $settings = [], ?int $timeout = null, bool $ack = false): void
+    {
+        $payload = '';
+        foreach ($settings as $identifier => $value) {
+            $payload .= pack('nN', $identifier, $value);
+        }
+
+        $this->sendFrame(
+            new H2Frame(
+                H2Frame::TYPE_SETTINGS,
+                $ack ? H2Frame::FLAG_ACK : 0,
+                0,
+                $payload
+            ),
+            $timeout
+        );
+    }
+
+    public function sendPingAck(string $opaqueData, ?int $timeout = null): void
+    {
+        $this->sendFrame(
+            new H2Frame(
+                H2Frame::TYPE_PING,
+                H2Frame::FLAG_ACK,
+                0,
+                $this->normalizePingOpaqueData($opaqueData)
+            ),
+            $timeout
+        );
+    }
+
+    public function goAway(
+        int $errorCode = H2Exception::ERROR_NO_ERROR,
+        int $lastStreamId = 0,
+        string $debugData = '',
+        ?int $timeout = null
+    ): void {
+        if ($lastStreamId < 0 || $lastStreamId > H2Frame::MAX_STREAM_ID) {
+            throw H2Exception::forConnectionError('GOAWAY last stream ID out of range');
+        }
+
+        $payload = pack('NN', $lastStreamId & H2Frame::MAX_STREAM_ID, $errorCode) . $debugData;
+        $this->goAwaySent = true;
+        $this->lastAllowedStreamId = min($this->lastAllowedStreamId, $lastStreamId);
+        $this->sendFrame(new H2Frame(H2Frame::TYPE_GOAWAY, 0, 0, $payload), $timeout);
+    }
+
+    public function sendRstStream(
+        int $streamId,
+        int $errorCode = H2Exception::ERROR_PROTOCOL_ERROR,
+        ?int $timeout = null
+    ): void {
+        $this->markStreamClosed($streamId);
+        $this->sendFrame(H2Frame::createRstStream($streamId, $errorCode), $timeout);
+    }
+
+    public function noteResponseEnd(int $streamId): void
+    {
+        $this->noteLocalStreamEnded($streamId);
+    }
+
+    public function beginUpgradedRequestStream(int $streamId = 1, bool $remoteEnded = true): void
+    {
+        $this->assertCanAcceptRequestStream($streamId);
+        $this->noteRemoteStreamOpened($streamId, $remoteEnded);
+        $this->markRequestStreamProcessed($streamId);
+    }
+
+    public function assertCanAcceptRequestStream(int $streamId): void
+    {
+        if ($streamId < 1 || ($streamId % 2) === 0) {
+            throw H2Exception::forConnectionError('Request HEADERS frame must use an odd positive stream ID');
+        }
+
+        if ($this->isExistingRequestStream($streamId)) {
+            return;
+        }
+
+        $this->assertStreamAllowedAfterGoAway($streamId);
+    }
+
+    public function markRequestStreamProcessed(int $streamId): void
+    {
+        $this->lastProcessedStreamId = max($this->lastProcessedStreamId, $streamId);
+    }
+
+    public function isExistingRequestStream(int $streamId): bool
+    {
+        return $streamId > 0 && $streamId <= $this->lastProcessedStreamId && !$this->isStreamClosed($streamId);
+    }
+
+    public function assertCanUseResponseStream(int $streamId): void
+    {
+        if ($streamId < 1) {
+            throw H2Exception::forConnectionError('Response stream ID must be positive');
+        }
+
+        $this->assertCanSendOnStream($streamId);
+
+        if ($this->isExistingRequestStream($streamId)) {
+            return;
+        }
+
+        $this->assertStreamAllowedAfterGoAway($streamId);
+    }
+
+    public function assertCanSendOnStream(int $streamId): void
+    {
+        H2StreamStateMatrix::assertCanSend($streamId, $this->streamStates[$streamId] ?? null);
+    }
+
+    public function assertCanReceiveDataOnStream(int $streamId): void
+    {
+        H2StreamStateMatrix::assertCanReceiveData($streamId, $this->streamStates[$streamId] ?? null);
+    }
+
+    private function assertStreamAllowedAfterGoAway(int $streamId): void
+    {
+        if (($this->goAwaySent || $this->goAwayReceived) && $streamId > $this->lastAllowedStreamId) {
+            throw H2Exception::forStreamError(
+                $streamId,
+                'New stream is not allowed after GOAWAY',
+                H2Exception::ERROR_REFUSED_STREAM
+            );
+        }
+    }
+
+    public function markStreamClosed(int $streamId): void
+    {
+        if ($streamId > 0) {
+            $this->closedStreams[$streamId] = true;
+            $this->streamStates[$streamId] = self::STREAM_STATE_CLOSED;
+        }
+    }
+
+    protected function readBytes(int $length, ?int $timeout = null): string
+    {
+        if ($length === 0) {
+            return '';
+        }
+
+        while ($this->bufferedLength < $length) {
+            $read = $this->recvToBuffer($timeout);
+            if ($read <= 0) {
+                throw H2Exception::forConnectionError('Connection closed while reading HTTP/2 bytes');
+            }
+        }
+
+        $chunk = $this->buffer->read(0, $length);
+        $remaining = $this->bufferedLength - $length;
+
+        if ($remaining > 0) {
+            $tail = $this->buffer->read($length, $remaining);
+            $this->buffer->clear();
+            $this->buffer->append($tail);
+            $this->bufferedLength = $remaining;
+        } else {
+            $this->buffer->clear();
+            $this->bufferedLength = 0;
+        }
+
+        return $chunk;
+    }
+
+    protected function recvToBuffer(?int $timeout = null): int
+    {
+        $free = $this->buffer->getSize() - $this->bufferedLength;
+        if ($free <= 0) {
+            throw H2Exception::forConnectionError('H2 receive buffer exhausted');
+        }
+
+        try {
+            $read = $this->socket->recv($this->buffer, $this->bufferedLength, $free, $timeout);
+        } catch (SocketException $exception) {
+            throw H2Exception::forConnectionError(
+                'Failed to receive H2 bytes: ' . $exception->getMessage(),
+                H2Exception::ERROR_INTERNAL_ERROR,
+                $exception
+            );
+        }
+
+        $this->bufferedLength += $read;
+
+        return $read;
+    }
+
+    protected function normalizePingOpaqueData(string $opaqueData): string
+    {
+        $length = strlen($opaqueData);
+        if ($length === 8) {
+            return $opaqueData;
+        }
+
+        if ($length > 8) {
+            return substr($opaqueData, 0, 8);
+        }
+
+        return $opaqueData . str_repeat("\x00", 8 - $length);
+    }
+
+    protected function consumeReceiveWindow(int $streamId, int $bytes): void
+    {
+        if ($bytes === 0) {
+            return;
+        }
+
+        if ($this->connectionReceiveWindow < $bytes) {
+            throw H2Exception::forConnectionError('Connection receive window exhausted', H2Exception::ERROR_FLOW_CONTROL_ERROR);
+        }
+
+        $streamWindow = $this->streamReceiveWindows[$streamId] ?? $this->streamInitialWindowSize;
+        if ($streamWindow < $bytes) {
+            throw H2Exception::forStreamError(
+                $streamId,
+                'Stream receive window exhausted',
+                H2Exception::ERROR_FLOW_CONTROL_ERROR
+            );
+        }
+
+        $this->connectionReceiveWindow -= $bytes;
+        $this->streamReceiveWindows[$streamId] = $streamWindow - $bytes;
+        $this->connectionBytesConsumed[$streamId] = ($this->connectionBytesConsumed[$streamId] ?? 0) + $bytes;
+        $this->streamBytesConsumed[$streamId] = ($this->streamBytesConsumed[$streamId] ?? 0) + $bytes;
+
+        if ($this->connectionBytesConsumed[$streamId] >= self::DEFAULT_WINDOW_UPDATE_THRESHOLD) {
+            $increment = $this->connectionBytesConsumed[$streamId];
+            $this->connectionBytesConsumed[$streamId] = 0;
+            $this->connectionReceiveWindow += $increment;
+            $this->sendFrame(H2Frame::createWindowUpdate(0, $increment));
+        }
+
+        if ($this->streamBytesConsumed[$streamId] >= self::DEFAULT_WINDOW_UPDATE_THRESHOLD) {
+            $increment = $this->streamBytesConsumed[$streamId];
+            $this->streamBytesConsumed[$streamId] = 0;
+            $this->streamReceiveWindows[$streamId] += $increment;
+            $this->sendFrame(H2Frame::createWindowUpdate($streamId, $increment));
+        }
+    }
+
+    private function validateSettingsFrame(H2Frame $frame): H2Frame
+    {
+        if ($frame->streamId !== 0) {
+            throw H2Exception::forConnectionError('SETTINGS frame must use stream 0');
+        }
+
+        if (($frame->flags & H2Frame::FLAG_ACK) !== 0) {
+            if ($frame->payload !== '') {
+                throw H2Exception::forConnectionError(
+                    'SETTINGS ACK frame must not contain a payload',
+                    H2Exception::ERROR_FRAME_SIZE_ERROR
+                );
+            }
+
+            return $frame;
+        }
+
+        if ((strlen($frame->payload) % 6) !== 0) {
+            throw H2Exception::forConnectionError(
+                'SETTINGS payload length must be a multiple of 6',
+                H2Exception::ERROR_FRAME_SIZE_ERROR
+            );
+        }
+
+        $this->applySettingsPayload($frame->payload);
+
+        return $frame;
+    }
+
+    private function applySettingsPayload(string $payload): void
+    {
+        $length = strlen($payload);
+        for ($offset = 0; $offset < $length; $offset += 6) {
+            $setting = unpack('nidentifier/Nvalue', substr($payload, $offset, 6));
+            $identifier = $setting['identifier'] ?? 0;
+            $value = $setting['value'] ?? 0;
+
+            match ($identifier) {
+                self::SETTINGS_INITIAL_WINDOW_SIZE => $this->applyInitialWindowSize($value),
+                self::SETTINGS_MAX_FRAME_SIZE => $this->applyMaxFrameSize($value),
+                default => null,
+            };
+        }
+    }
+
+    private function applyInitialWindowSize(int $value): void
+    {
+        if ($value > H2Frame::MAX_WINDOW_SIZE) {
+            throw H2Exception::forConnectionError(
+                'SETTINGS_INITIAL_WINDOW_SIZE exceeds maximum allowed value',
+                H2Exception::ERROR_FLOW_CONTROL_ERROR
+            );
+        }
+
+        $delta = $value - $this->streamInitialWindowSize;
+        $sendDelta = $value - $this->streamSendInitialWindowSize;
+        $this->streamInitialWindowSize = $value;
+        $this->streamSendInitialWindowSize = $value;
+
+        foreach ($this->streamReceiveWindows as $streamId => $window) {
+            $nextWindow = $window + $delta;
+            if ($nextWindow > H2Frame::MAX_WINDOW_SIZE) {
+                throw H2Exception::forStreamError(
+                    $streamId,
+                    'Adjusted stream receive window exceeds maximum allowed value',
+                    H2Exception::ERROR_FLOW_CONTROL_ERROR
+                );
+            }
+
+            $this->streamReceiveWindows[$streamId] = $nextWindow;
+        }
+
+        foreach ($this->streamSendWindows as $streamId => $window) {
+            $nextWindow = $window + $sendDelta;
+            if ($nextWindow > H2Frame::MAX_WINDOW_SIZE) {
+                throw H2Exception::forStreamError(
+                    $streamId,
+                    'Adjusted stream send window exceeds maximum allowed value',
+                    H2Exception::ERROR_FLOW_CONTROL_ERROR
+                );
+            }
+
+            $this->streamSendWindows[$streamId] = $nextWindow;
+        }
+    }
+
+    private function applyMaxFrameSize(int $value): void
+    {
+        if ($value < self::MIN_MAX_FRAME_SIZE || $value > self::MAX_MAX_FRAME_SIZE) {
+            throw H2Exception::forConnectionError(
+                'SETTINGS_MAX_FRAME_SIZE out of allowed range',
+                H2Exception::ERROR_PROTOCOL_ERROR
+            );
+        }
+
+        $this->localMaxFrameSize = $value;
+    }
+
+    private function validatePingFrame(H2Frame $frame): H2Frame
+    {
+        if ($frame->streamId !== 0) {
+            throw H2Exception::forConnectionError('PING frame must use stream 0');
+        }
+
+        if (strlen($frame->payload) !== 8) {
+            throw H2Exception::forConnectionError(
+                'PING payload length must be exactly 8',
+                H2Exception::ERROR_FRAME_SIZE_ERROR
+            );
+        }
+
+        return $frame;
+    }
+
+    private function validatePriorityFrame(H2Frame $frame): H2Frame
+    {
+        if ($frame->streamId < 1) {
+            throw H2Exception::forConnectionError('PRIORITY frame must use a positive stream ID');
+        }
+
+        if (strlen($frame->payload) !== 5) {
+            throw H2Exception::forConnectionError(
+                'PRIORITY payload length must be exactly 5',
+                H2Exception::ERROR_FRAME_SIZE_ERROR
+            );
+        }
+
+        return $frame;
+    }
+
+    private function validatePushPromiseFrame(H2Frame $frame): H2Frame
+    {
+        throw H2Exception::forConnectionError(
+            'Client must not send PUSH_PROMISE frames',
+            H2Exception::ERROR_PROTOCOL_ERROR
+        );
+    }
+
+    private function validateGoAwayFrame(H2Frame $frame): H2Frame
+    {
+        if ($frame->streamId !== 0) {
+            throw H2Exception::forConnectionError('GOAWAY frame must use stream 0');
+        }
+
+        if (strlen($frame->payload) < 8) {
+            throw H2Exception::forConnectionError(
+                'GOAWAY payload length must be at least 8',
+                H2Exception::ERROR_FRAME_SIZE_ERROR
+            );
+        }
+
+        $lastStreamId = (unpack('N', substr($frame->payload, 0, 4))[1] ?? 0) & H2Frame::MAX_STREAM_ID;
+        $this->goAwayReceived = true;
+        $this->lastAllowedStreamId = min($this->lastAllowedStreamId, $lastStreamId);
+
+        return $frame;
+    }
+
+    private function validateWindowUpdateFrame(H2Frame $frame): H2Frame
+    {
+        if (strlen($frame->payload) !== 4) {
+            throw H2Exception::forConnectionError(
+                'WINDOW_UPDATE payload length must be exactly 4',
+                H2Exception::ERROR_FRAME_SIZE_ERROR
+            );
+        }
+
+        $increment = (unpack('N', $frame->payload)[1] ?? 0) & H2Frame::MAX_WINDOW_SIZE;
+        if ($increment === 0) {
+            throw H2Exception::forConnectionError('WINDOW_UPDATE increment must not be 0');
+        }
+
+        if ($frame->streamId > 0 && $this->isStreamClosed($frame->streamId)) {
+            throw H2Exception::forStreamError(
+                $frame->streamId,
+                'WINDOW_UPDATE received for closed stream',
+                H2Exception::ERROR_STREAM_CLOSED
+            );
+        }
+
+        $this->applySendWindowUpdate($frame->streamId, $increment);
+
+        return $frame;
+    }
+
+    private function validateRstStreamFrame(H2Frame $frame): H2Frame
+    {
+        if ($frame->streamId < 1) {
+            throw H2Exception::forConnectionError('RST_STREAM frame must use a positive stream ID');
+        }
+
+        if (strlen($frame->payload) !== 4) {
+            throw H2Exception::forConnectionError(
+                'RST_STREAM payload length must be exactly 4',
+                H2Exception::ERROR_FRAME_SIZE_ERROR
+            );
+        }
+
+        $this->markStreamClosed($frame->streamId);
+
+        return $frame;
+    }
+
+    private function validateOpenStreamFrame(H2Frame $frame): H2Frame
+    {
+        $state = $this->streamStates[$frame->streamId] ?? null;
+        H2StreamStateMatrix::validateInboundFrame(
+            $frame,
+            $state,
+            $this->isStreamClosed($frame->streamId),
+            $frame->streamId > 0
+                && $frame->type === H2Frame::TYPE_DATA
+                && $state === null
+                && !$this->isExistingRequestStream($frame->streamId),
+            $frame->streamId > 0
+                && $frame->type === H2Frame::TYPE_CONTINUATION
+                && $state === null
+                && $this->activeHeaderBlockStreamId !== $frame->streamId
+                && !$this->scheduler->hasPendingRequestStartFrameForStream($frame->streamId)
+        );
+
+        return $frame;
+    }
+
+    private function pumpControlFrame(H2Frame $frame, ?int $timeout = null): void
+    {
+        match ($frame->type) {
+            H2Frame::TYPE_SETTINGS => $this->ackSettingsFrameIfNeeded($frame, $timeout),
+            H2Frame::TYPE_PING => $this->ackPingFrameIfNeeded($frame, $timeout),
+            H2Frame::TYPE_GOAWAY,
+            H2Frame::TYPE_WINDOW_UPDATE,
+            H2Frame::TYPE_RST_STREAM => null,
+            default => throw H2Exception::forConnectionError('Expected HEADERS frame to start header block'),
+        };
+    }
+
+    private function ackSettingsFrameIfNeeded(H2Frame $frame, ?int $timeout = null): void
+    {
+        if (($frame->flags & H2Frame::FLAG_ACK) !== 0) {
+            return;
+        }
+
+        $this->sendSettings(timeout: $timeout, ack: true);
+    }
+
+    private function ackPingFrameIfNeeded(H2Frame $frame, ?int $timeout = null): void
+    {
+        if (($frame->flags & H2Frame::FLAG_ACK) !== 0) {
+            return;
+        }
+
+        $this->sendPingAck($frame->payload, $timeout);
+    }
+
+    private function isGracefulRequestStartTermination(Throwable $exception): bool
+    {
+        if ($exception instanceof SocketException) {
+            return true;
+        }
+
+        return $exception instanceof RuntimeException && $exception->getMessage() === 'No frame queued';
+    }
+
+    private function nextFrame(?int $timeout = null): H2Frame
+    {
+        return $this->scheduler->nextPendingFrame($this->readFrame(...), $timeout);
+    }
+
+    private function deferFrame(H2Frame $frame): void
+    {
+        $this->scheduler->defer($frame);
+    }
+
+    private function takePendingControlFrame(): ?H2Frame
+    {
+        return $this->scheduler->takePendingControlFrame();
+    }
+
+    private function isSendWindowControlFrame(H2Frame $frame): bool
+    {
+        return match ($frame->type) {
+            H2Frame::TYPE_SETTINGS,
+            H2Frame::TYPE_PING,
+            H2Frame::TYPE_GOAWAY,
+            H2Frame::TYPE_WINDOW_UPDATE,
+            H2Frame::TYPE_RST_STREAM => true,
+            default => false,
+        };
+    }
+
+    private function readTrailerHeaderBlock(H2Frame $frame, ?int $timeout = null): H2HeaderBlock
+    {
+        $trailerBlock = new H2HeaderBlock($frame->streamId);
+        $trailerBlock->append($frame);
+        $this->activeHeaderBlockStreamId = $frame->streamId;
+        try {
+            while (!$trailerBlock->isCompleted()) {
+                $continuation = $this->nextRelevantFrameForStream($frame->streamId, $timeout);
+                $trailerBlock->append($continuation);
+            }
+        } finally {
+            $this->activeHeaderBlockStreamId = null;
+        }
+
+        if (($trailerBlock->getFlags() & H2Frame::FLAG_END_STREAM) === 0) {
+            throw H2Exception::forConnectionError('Trailing HEADERS frame must end the request stream');
+        }
+
+        return $trailerBlock;
+    }
+
+    private function nextRelevantFrameForStream(int $streamId, ?int $timeout = null): H2Frame
+    {
+        return $this->scheduler->nextRelevantFrameForStream($this->readFrame(...), $streamId, $timeout);
+    }
+
+    private function takePendingRequestStartFrame(): ?H2Frame
+    {
+        return $this->scheduler->takePendingRequestStartFrame();
+    }
+
+    private function takePendingFrameForStream(int $streamId): ?H2Frame
+    {
+        return $this->scheduler->takePendingFrameForStream($streamId);
+    }
+
+    private function noteRemoteStreamOpened(int $streamId, bool $ended): void
+    {
+        if ($this->isStreamClosed($streamId)) {
+            return;
+        }
+
+        $this->streamStates[$streamId] = H2StreamStateMatrix::stateAfterRemoteOpened($ended);
+    }
+
+    private function noteRemoteStreamEnded(int $streamId): void
+    {
+        $nextState = H2StreamStateMatrix::stateAfterRemoteEnded($this->streamStates[$streamId] ?? null);
+        if ($nextState === self::STREAM_STATE_CLOSED) {
+            $this->markStreamClosed($streamId);
+
+            return;
+        }
+
+        if ($nextState !== null) {
+            $this->streamStates[$streamId] = $nextState;
+        }
+    }
+
+    private function noteLocalStreamEnded(int $streamId): void
+    {
+        $nextState = H2StreamStateMatrix::stateAfterLocalEnded($this->streamStates[$streamId] ?? null);
+        if ($nextState === self::STREAM_STATE_CLOSED) {
+            $this->markStreamClosed($streamId);
+
+            return;
+        }
+
+        if ($nextState !== null) {
+            $this->streamStates[$streamId] = $nextState;
+        }
+    }
+
+    private function applySendWindowUpdate(int $streamId, int $increment): void
+    {
+        if ($streamId === 0) {
+            $nextWindow = $this->connectionSendWindow + $increment;
+            if ($nextWindow > H2Frame::MAX_WINDOW_SIZE) {
+                throw H2Exception::forConnectionError(
+                    'Connection send window exceeds maximum allowed value',
+                    H2Exception::ERROR_FLOW_CONTROL_ERROR
+                );
+            }
+
+            $this->connectionSendWindow = $nextWindow;
+
+            return;
+        }
+
+        $currentWindow = $this->streamSendWindows[$streamId] ?? $this->streamSendInitialWindowSize;
+        $nextWindow = $currentWindow + $increment;
+        if ($nextWindow > H2Frame::MAX_WINDOW_SIZE) {
+            throw H2Exception::forStreamError(
+                $streamId,
+                'Stream send window exceeds maximum allowed value',
+                H2Exception::ERROR_FLOW_CONTROL_ERROR
+            );
+        }
+
+        $this->streamSendWindows[$streamId] = $nextWindow;
+    }
+}

--- a/lib/swow-library/src/Http/Protocol/H2Exception.php
+++ b/lib/swow-library/src/Http/Protocol/H2Exception.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * This file is part of Swow
+ *
+ * @link    https://github.com/swow/swow
+ * @contact twosee <twosee@php.net>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code
+ */
+
+declare(strict_types=1);
+
+namespace Swow\Http\Protocol;
+
+use RuntimeException;
+
+class H2Exception extends RuntimeException
+{
+    public const ERROR_NO_ERROR = 0x00;
+    public const ERROR_PROTOCOL_ERROR = 0x01;
+    public const ERROR_INTERNAL_ERROR = 0x02;
+    public const ERROR_FLOW_CONTROL_ERROR = 0x03;
+    public const ERROR_SETTINGS_TIMEOUT = 0x04;
+    public const ERROR_STREAM_CLOSED = 0x05;
+    public const ERROR_FRAME_SIZE_ERROR = 0x06;
+    public const ERROR_REFUSED_STREAM = 0x07;
+    public const ERROR_CANCEL = 0x08;
+    public const ERROR_COMPRESSION_ERROR = 0x09;
+    public const ERROR_CONNECT_ERROR = 0x0a;
+    public const ERROR_ENHANCE_YOUR_CALM = 0x0b;
+    public const ERROR_INADEQUATE_SECURITY = 0x0c;
+    public const ERROR_HTTP_1_1_REQUIRED = 0x0d;
+
+    public function __construct(
+        string $message,
+        protected int $errorCode = self::ERROR_INTERNAL_ERROR,
+        protected int $streamId = 0,
+        protected bool $connectionLevel = true,
+        int $code = 0,
+        ?\Throwable $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public static function forConnectionError(
+        string $message,
+        int $errorCode = self::ERROR_PROTOCOL_ERROR,
+        ?\Throwable $previous = null
+    ): static {
+        return new static($message, $errorCode, 0, true, 0, $previous);
+    }
+
+    public static function forStreamError(
+        int $streamId,
+        string $message,
+        int $errorCode = self::ERROR_PROTOCOL_ERROR,
+        ?\Throwable $previous = null
+    ): static {
+        return new static($message, $errorCode, $streamId, false, 0, $previous);
+    }
+
+    public function getH2ErrorCode(): int
+    {
+        return $this->errorCode;
+    }
+
+    public function getStreamId(): int
+    {
+        return $this->streamId;
+    }
+
+    public function isConnectionLevel(): bool
+    {
+        return $this->connectionLevel;
+    }
+}

--- a/lib/swow-library/src/Http/Protocol/H2Frame.php
+++ b/lib/swow-library/src/Http/Protocol/H2Frame.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * This file is part of Swow
+ *
+ * @link    https://github.com/swow/swow
+ * @contact twosee <twosee@php.net>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code
+ */
+
+declare(strict_types=1);
+
+namespace Swow\Http\Protocol;
+
+use function ord;
+use function pack;
+use function strlen;
+use function substr;
+use function unpack;
+
+final class H2Frame
+{
+    public const HEADER_LENGTH = 9;
+    public const MAX_STREAM_ID = 0x7fffffff;
+    public const MAX_WINDOW_SIZE = 0x7fffffff;
+    public const DEFAULT_MAX_FRAME_SIZE = 16_384;
+
+    public const TYPE_DATA = 0x00;
+    public const TYPE_HEADERS = 0x01;
+    public const TYPE_PRIORITY = 0x02;
+    public const TYPE_RST_STREAM = 0x03;
+    public const TYPE_SETTINGS = 0x04;
+    public const TYPE_PUSH_PROMISE = 0x05;
+    public const TYPE_PING = 0x06;
+    public const TYPE_GOAWAY = 0x07;
+    public const TYPE_WINDOW_UPDATE = 0x08;
+    public const TYPE_CONTINUATION = 0x09;
+
+    public const FLAG_END_STREAM = 0x01;
+    public const FLAG_ACK = 0x01;
+    public const FLAG_END_HEADERS = 0x04;
+
+    public function __construct(
+        public int $type,
+        public int $flags,
+        public int $streamId,
+        public string $payload = '',
+    ) {}
+
+    public static function fromHeaderAndPayload(string $header, string $payload): static
+    {
+        if (strlen($header) !== self::HEADER_LENGTH) {
+            throw H2Exception::forConnectionError('Invalid frame header length', H2Exception::ERROR_FRAME_SIZE_ERROR);
+        }
+
+        $length =
+            (ord($header[0]) << 16) |
+            (ord($header[1]) << 8) |
+            ord($header[2]);
+        $type = ord($header[3]);
+        $flags = ord($header[4]);
+        $streamId = (unpack('N', substr($header, 5, 4))[1] ?? 0) & self::MAX_STREAM_ID;
+
+        if (strlen($payload) !== $length) {
+            throw H2Exception::forConnectionError('Frame payload length mismatch', H2Exception::ERROR_FRAME_SIZE_ERROR);
+        }
+
+        return new static($type, $flags, $streamId, $payload);
+    }
+
+    public static function decodeHeader(string $header): array
+    {
+        if (strlen($header) !== self::HEADER_LENGTH) {
+            throw H2Exception::forConnectionError('Invalid frame header length', H2Exception::ERROR_FRAME_SIZE_ERROR);
+        }
+
+        return [
+            'length' => (ord($header[0]) << 16) | (ord($header[1]) << 8) | ord($header[2]),
+            'type' => ord($header[3]),
+            'flags' => ord($header[4]),
+            'streamId' => (unpack('N', substr($header, 5, 4))[1] ?? 0) & self::MAX_STREAM_ID,
+        ];
+    }
+
+    public static function encodeHeader(int $length, int $type, int $flags, int $streamId): string
+    {
+        if ($length < 0 || $length > 0x00ffffff) {
+            throw H2Exception::forConnectionError('Frame length out of range', H2Exception::ERROR_FRAME_SIZE_ERROR);
+        }
+
+        if ($streamId < 0 || $streamId > self::MAX_STREAM_ID) {
+            throw H2Exception::forConnectionError('Frame stream ID out of range');
+        }
+
+        return
+            pack('C', ($length >> 16) & 0xff) .
+            pack('C', ($length >> 8) & 0xff) .
+            pack('C', $length & 0xff) .
+            pack('C', $type & 0xff) .
+            pack('C', $flags & 0xff) .
+            pack('N', $streamId & self::MAX_STREAM_ID);
+    }
+
+    public function encode(): string
+    {
+        return self::encodeHeader(strlen($this->payload), $this->type, $this->flags, $this->streamId) . $this->payload;
+    }
+
+    public static function createWindowUpdate(int $streamId, int $increment): static
+    {
+        if ($streamId < 0 || $streamId > self::MAX_STREAM_ID) {
+            throw H2Exception::forConnectionError('WINDOW_UPDATE stream ID out of range');
+        }
+
+        if ($increment < 1 || $increment > self::MAX_WINDOW_SIZE) {
+            throw H2Exception::forConnectionError('WINDOW_UPDATE increment out of range');
+        }
+
+        return new static(
+            self::TYPE_WINDOW_UPDATE,
+            0,
+            $streamId,
+            pack('N', $increment & self::MAX_WINDOW_SIZE)
+        );
+    }
+
+    public static function createRstStream(int $streamId, int $errorCode): static
+    {
+        if ($streamId < 1 || $streamId > self::MAX_STREAM_ID) {
+            throw H2Exception::forConnectionError('RST_STREAM stream ID out of range');
+        }
+
+        return new static(
+            self::TYPE_RST_STREAM,
+            0,
+            $streamId,
+            pack('N', $errorCode)
+        );
+    }
+}

--- a/lib/swow-library/src/Http/Protocol/H2FrameScheduler.php
+++ b/lib/swow-library/src/Http/Protocol/H2FrameScheduler.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swow\Http\Protocol;
+
+use Throwable;
+
+final class H2FrameScheduler
+{
+    /** @var callable(H2Frame): bool */
+    private mixed $isControlFrame;
+
+    /**
+     * @param callable(H2Frame): bool $isControlFrame
+     */
+    public function __construct(
+        private H2PendingFrameQueue $pendingFrames,
+        callable $isControlFrame,
+    ) {
+        $this->isControlFrame = $isControlFrame;
+    }
+
+    public function defer(H2Frame $frame): void
+    {
+        $this->pendingFrames->defer($frame);
+    }
+
+    /**
+     * @param callable(?int): H2Frame $readFrame
+     */
+    public function nextPendingFrame(callable $readFrame, ?int $timeout = null): H2Frame
+    {
+        $pendingFrame = $this->pendingFrames->shift();
+        if ($pendingFrame instanceof H2Frame) {
+            return $pendingFrame;
+        }
+
+        return $readFrame($timeout);
+    }
+
+    public function takePendingControlFrame(): ?H2Frame
+    {
+        return $this->pendingFrames->takeControlFrame($this->isControlFrame);
+    }
+
+    public function takePendingRequestStartFrame(): ?H2Frame
+    {
+        return $this->pendingFrames->takeRequestStartFrame();
+    }
+
+    public function takePendingFrameForStream(int $streamId): ?H2Frame
+    {
+        return $this->pendingFrames->takeFrameForStream($streamId, $this->isControlFrame);
+    }
+
+    public function hasPendingRequestStartFrameForStream(int $streamId): bool
+    {
+        return $this->pendingFrames->hasRequestStartFrameForStream($streamId);
+    }
+
+    /**
+     * @param callable(?int): H2Frame $readFrame
+     * @param callable(H2Frame, ?int): void $pumpControlFrame
+     * @param callable(): bool $canAcceptNewRequests
+     * @param callable(Throwable): bool $isGracefulTermination
+     */
+    public function nextRequestStartFrame(
+        callable $readFrame,
+        callable $pumpControlFrame,
+        callable $canAcceptNewRequests,
+        callable $isGracefulTermination,
+        ?int $timeout = null,
+    ): ?H2Frame {
+        if (!$canAcceptNewRequests()) {
+            return null;
+        }
+
+        while (true) {
+            $pendingControlFrame = $this->takePendingControlFrame();
+            if ($pendingControlFrame instanceof H2Frame) {
+                $pumpControlFrame($pendingControlFrame, $timeout);
+                if (!$canAcceptNewRequests()) {
+                    return null;
+                }
+
+                continue;
+            }
+
+            $pendingRequestStartFrame = $this->takePendingRequestStartFrame();
+            if ($pendingRequestStartFrame instanceof H2Frame) {
+                return $pendingRequestStartFrame;
+            }
+
+            try {
+                $frame = $readFrame($timeout);
+            } catch (Throwable $exception) {
+                if ($isGracefulTermination($exception)) {
+                    return null;
+                }
+
+                throw $exception;
+            }
+
+            if ($frame->type === H2Frame::TYPE_HEADERS) {
+                return $frame;
+            }
+
+            if ($this->isControlFrame($frame)) {
+                $pumpControlFrame($frame, $timeout);
+            } else {
+                $this->defer($frame);
+            }
+
+            if (!$canAcceptNewRequests()) {
+                return null;
+            }
+        }
+    }
+
+    /**
+     * @param callable(?int): H2Frame $readFrame
+     */
+    public function nextRelevantFrameForStream(
+        callable $readFrame,
+        int $streamId,
+        ?int $timeout = null,
+    ): H2Frame {
+        $pendingFrame = $this->takePendingFrameForStream($streamId);
+        if ($pendingFrame instanceof H2Frame) {
+            return $pendingFrame;
+        }
+
+        while (true) {
+            $frame = $readFrame($timeout);
+            if ($frame->streamId === $streamId || $this->isControlFrame($frame)) {
+                return $frame;
+            }
+
+            $this->defer($frame);
+        }
+    }
+
+    private function isControlFrame(H2Frame $frame): bool
+    {
+        return ($this->isControlFrame)($frame);
+    }
+}

--- a/lib/swow-library/src/Http/Protocol/H2HeaderBlock.php
+++ b/lib/swow-library/src/Http/Protocol/H2HeaderBlock.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * This file is part of Swow
+ *
+ * @link    https://github.com/swow/swow
+ * @contact twosee <twosee@php.net>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code
+ */
+
+declare(strict_types=1);
+
+namespace Swow\Http\Protocol;
+
+final class H2HeaderBlock
+{
+    private string $buffer = '';
+
+    private bool $completed = false;
+
+    public function __construct(
+        private int $streamId,
+        private int $flags = 0,
+    ) {}
+
+    public function getStreamId(): int
+    {
+        return $this->streamId;
+    }
+
+    public function isCompleted(): bool
+    {
+        return $this->completed;
+    }
+
+    public function getFlags(): int
+    {
+        return $this->flags;
+    }
+
+    public function append(H2Frame $frame): void
+    {
+        if ($this->completed) {
+            throw H2Exception::forStreamError($this->streamId, 'Header block already completed');
+        }
+
+        if ($frame->streamId !== $this->streamId) {
+            throw H2Exception::forConnectionError('CONTINUATION frame stream does not match active header block');
+        }
+
+        if ($frame->type !== H2Frame::TYPE_HEADERS && $frame->type !== H2Frame::TYPE_CONTINUATION) {
+            throw H2Exception::forConnectionError('Header block was interrupted by a non-continuation frame');
+        }
+
+        $this->buffer .= $frame->payload;
+        $this->flags = $frame->flags;
+        if (($frame->flags & H2Frame::FLAG_END_HEADERS) !== 0) {
+            $this->completed = true;
+        }
+    }
+
+    public function getBuffer(): string
+    {
+        return $this->buffer;
+    }
+}

--- a/lib/swow-library/src/Http/Protocol/H2Headers.php
+++ b/lib/swow-library/src/Http/Protocol/H2Headers.php
@@ -1,0 +1,262 @@
+<?php
+
+/**
+ * This file is part of Swow
+ *
+ * @link    https://github.com/swow/swow
+ * @contact twosee <twosee@php.net>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code
+ */
+
+declare(strict_types=1);
+
+namespace Swow\Http\Protocol;
+
+use Swow\Http\Message\ServerRequestEntity;
+
+use function array_key_exists;
+use function explode;
+use function is_array;
+use function is_string;
+use function preg_match;
+use function strlen;
+use function strtolower;
+use function trim;
+
+final class H2Headers
+{
+    /**
+     * @param array<int, array{name: string, value: string}|array{0: string, 1: string}> $headers
+     */
+    public static function createServerRequestEntity(array $headers, array $serverParams = []): ServerRequestEntity
+    {
+        $entity = new ServerRequestEntity();
+        $entity->protocolVersion = '2.0';
+        $entity->shouldKeepAlive = true;
+        $entity->serverParams = $serverParams + $entity->serverParams;
+
+        $pseudoHeaders = [];
+        foreach ($headers as $header) {
+            [$name, $value] = self::normalizeHeader($header);
+
+            if ($name === '') {
+                throw H2Exception::forConnectionError('H2 header name must not be empty');
+            }
+
+            if ($name[0] === ':') {
+                if (array_key_exists($name, $pseudoHeaders)) {
+                    throw H2Exception::forConnectionError('Duplicate pseudo-header "' . $name . '"');
+                }
+
+                $pseudoHeaders[$name] = $value;
+                continue;
+            }
+
+            if (!preg_match('/^[a-z0-9!#$%&\'*+.^_`|~-]+$/', $name)) {
+                throw H2Exception::forConnectionError('Invalid H2 header name "' . $name . '"');
+            }
+
+            $entity->headers[$name] ??= [];
+            $entity->headers[$name][] = $value;
+            $entity->headerNames[$name] ??= $name;
+        }
+
+        $entity->method = self::requirePseudoHeader($pseudoHeaders, ':method');
+        $entity->uri = self::buildRequestUri($pseudoHeaders);
+
+        if (isset($pseudoHeaders[':authority']) && !isset($entity->headers['host'])) {
+            $entity->headers['host'] = [$pseudoHeaders[':authority']];
+            $entity->headerNames['host'] = 'host';
+        }
+
+        if (isset($entity->headers['cookie'])) {
+            $entity->cookies = self::parseCookies($entity->headers['cookie']);
+        }
+
+        return $entity;
+    }
+
+    /**
+     * @param array<string, array<string>|string> $headers
+     */
+    public static function encodeResponseHeaders(int $statusCode, array $headers = []): string
+    {
+        $status = (string) $statusCode;
+        $block = self::encodeLiteralHeader(':status', $status);
+
+        foreach ($headers as $name => $value) {
+            $values = is_array($value) ? $value : [$value];
+            $lowerName = strtolower($name);
+
+            if ($lowerName === '' || $lowerName[0] === ':') {
+                throw H2Exception::forConnectionError('Response headers must not contain pseudo-headers');
+            }
+
+            foreach ($values as $singleValue) {
+                $block .= self::encodeLiteralHeader($lowerName, (string) $singleValue);
+            }
+        }
+
+        return $block;
+    }
+
+    /**
+     * @param array<int, array{name: string, value: string}|array{0: string, 1: string}> $headers
+     * @return array<string, list<string>>
+     */
+    public static function createTrailerMap(array $headers): array
+    {
+        $trailers = [];
+        foreach ($headers as $header) {
+            [$name, $value] = self::normalizeHeader($header);
+
+            if ($name === '') {
+                throw H2Exception::forConnectionError('H2 trailer name must not be empty');
+            }
+
+            if ($name[0] === ':') {
+                throw H2Exception::forConnectionError('Trailer headers must not contain pseudo-headers');
+            }
+
+            if (!preg_match('/^[a-z0-9!#$%&\'*+.^_`|~-]+$/', $name)) {
+                throw H2Exception::forConnectionError('Invalid H2 trailer name "' . $name . '"');
+            }
+
+            $trailers[$name] ??= [];
+            $trailers[$name][] = $value;
+        }
+
+        return $trailers;
+    }
+
+    /**
+     * @param array<string, array<string>|string> $headers
+     */
+    public static function encodeTrailerHeaders(array $headers): string
+    {
+        $block = '';
+        foreach ($headers as $name => $value) {
+            $values = is_array($value) ? $value : [$value];
+            $lowerName = strtolower($name);
+
+            if ($lowerName === '' || $lowerName[0] === ':') {
+                throw H2Exception::forConnectionError('Trailer headers must not contain pseudo-headers');
+            }
+
+            foreach ($values as $singleValue) {
+                $block .= self::encodeLiteralHeader($lowerName, (string) $singleValue);
+            }
+        }
+
+        return $block;
+    }
+
+    /**
+     * @param array{name: string, value: string}|array{0: string, 1: string} $header
+     * @return array{string, string}
+     */
+    private static function normalizeHeader(array $header): array
+    {
+        if (isset($header['name'], $header['value'])) {
+            return [strtolower($header['name']), $header['value']];
+        }
+
+        if (isset($header[0], $header[1]) && is_string($header[0]) && is_string($header[1])) {
+            return [strtolower($header[0]), $header[1]];
+        }
+
+        throw H2Exception::forConnectionError('Invalid H2 header tuple');
+    }
+
+    /**
+     * @param array<string, string> $pseudoHeaders
+     */
+    private static function buildRequestUri(array $pseudoHeaders): string
+    {
+        $authority = self::requirePseudoHeader($pseudoHeaders, ':authority');
+        $method = self::requirePseudoHeader($pseudoHeaders, ':method');
+
+        if ($method === 'CONNECT') {
+            return $authority;
+        }
+
+        $scheme = self::requirePseudoHeader($pseudoHeaders, ':scheme');
+        $path = self::requirePseudoHeader($pseudoHeaders, ':path');
+
+        return $scheme . '://' . $authority . $path;
+    }
+
+    /**
+     * @param array<string, string> $pseudoHeaders
+     */
+    private static function requirePseudoHeader(array $pseudoHeaders, string $name): string
+    {
+        $value = $pseudoHeaders[$name] ?? '';
+        if ($value === '') {
+            throw H2Exception::forConnectionError('Missing required pseudo-header "' . $name . '"');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string> $cookieHeaders
+     * @return array<string, string>
+     */
+    private static function parseCookies(array $cookieHeaders): array
+    {
+        $cookies = [];
+        foreach ($cookieHeaders as $cookieHeader) {
+            $pairs = explode(';', $cookieHeader);
+            foreach ($pairs as $pair) {
+                $pair = trim($pair);
+                if ($pair === '') {
+                    continue;
+                }
+
+                [$name, $value] = array_pad(explode('=', $pair, 2), 2, '');
+                $name = trim($name);
+                if ($name === '') {
+                    continue;
+                }
+
+                $cookies[$name] = trim($value);
+            }
+        }
+
+        return $cookies;
+    }
+
+    private static function encodeLiteralHeader(string $name, string $value): string
+    {
+        return
+            "\x00" .
+            self::encodeString($name) .
+            self::encodeString($value);
+    }
+
+    private static function encodeString(string $value): string
+    {
+        return self::encodeInteger(strlen($value), 7, 0) . $value;
+    }
+
+    private static function encodeInteger(int $value, int $prefixBits, int $prefixMask): string
+    {
+        $maxPrefixValue = (1 << $prefixBits) - 1;
+        if ($value < $maxPrefixValue) {
+            return chr($prefixMask | $value);
+        }
+
+        $encoded = chr($prefixMask | $maxPrefixValue);
+        $value -= $maxPrefixValue;
+
+        while ($value >= 128) {
+            $encoded .= chr(($value % 128) + 128);
+            $value = intdiv($value, 128);
+        }
+
+        return $encoded . chr($value);
+    }
+}

--- a/lib/swow-library/src/Http/Protocol/H2Hpack.php
+++ b/lib/swow-library/src/Http/Protocol/H2Hpack.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swow\Http\Protocol;
+
+use function ord;
+use function strlen;
+use function substr;
+
+final class H2Hpack
+{
+    /**
+     * @var list<array{name: string, value: string}>
+     */
+    private const STATIC_TABLE = [
+        ['name' => ':authority', 'value' => ''],
+        ['name' => ':method', 'value' => 'GET'],
+        ['name' => ':method', 'value' => 'POST'],
+        ['name' => ':path', 'value' => '/'],
+        ['name' => ':path', 'value' => '/index.html'],
+        ['name' => ':scheme', 'value' => 'http'],
+        ['name' => ':scheme', 'value' => 'https'],
+        ['name' => ':status', 'value' => '200'],
+        ['name' => ':status', 'value' => '204'],
+        ['name' => ':status', 'value' => '206'],
+        ['name' => ':status', 'value' => '304'],
+        ['name' => ':status', 'value' => '400'],
+        ['name' => ':status', 'value' => '404'],
+        ['name' => ':status', 'value' => '500'],
+        ['name' => 'accept-charset', 'value' => ''],
+        ['name' => 'accept-encoding', 'value' => 'gzip, deflate'],
+        ['name' => 'accept-language', 'value' => ''],
+        ['name' => 'accept-ranges', 'value' => ''],
+        ['name' => 'accept', 'value' => ''],
+        ['name' => 'access-control-allow-origin', 'value' => ''],
+        ['name' => 'age', 'value' => ''],
+        ['name' => 'allow', 'value' => ''],
+        ['name' => 'authorization', 'value' => ''],
+        ['name' => 'cache-control', 'value' => ''],
+        ['name' => 'content-disposition', 'value' => ''],
+        ['name' => 'content-encoding', 'value' => ''],
+        ['name' => 'content-language', 'value' => ''],
+        ['name' => 'content-length', 'value' => ''],
+        ['name' => 'content-location', 'value' => ''],
+        ['name' => 'content-range', 'value' => ''],
+        ['name' => 'content-type', 'value' => ''],
+        ['name' => 'cookie', 'value' => ''],
+        ['name' => 'date', 'value' => ''],
+        ['name' => 'etag', 'value' => ''],
+        ['name' => 'expect', 'value' => ''],
+        ['name' => 'expires', 'value' => ''],
+        ['name' => 'from', 'value' => ''],
+        ['name' => 'host', 'value' => ''],
+        ['name' => 'if-match', 'value' => ''],
+        ['name' => 'if-modified-since', 'value' => ''],
+        ['name' => 'if-none-match', 'value' => ''],
+        ['name' => 'if-range', 'value' => ''],
+        ['name' => 'if-unmodified-since', 'value' => ''],
+        ['name' => 'last-modified', 'value' => ''],
+        ['name' => 'link', 'value' => ''],
+        ['name' => 'location', 'value' => ''],
+        ['name' => 'max-forwards', 'value' => ''],
+        ['name' => 'proxy-authenticate', 'value' => ''],
+        ['name' => 'proxy-authorization', 'value' => ''],
+        ['name' => 'range', 'value' => ''],
+        ['name' => 'referer', 'value' => ''],
+        ['name' => 'refresh', 'value' => ''],
+        ['name' => 'retry-after', 'value' => ''],
+        ['name' => 'server', 'value' => ''],
+        ['name' => 'set-cookie', 'value' => ''],
+        ['name' => 'strict-transport-security', 'value' => ''],
+        ['name' => 'transfer-encoding', 'value' => ''],
+        ['name' => 'user-agent', 'value' => ''],
+        ['name' => 'vary', 'value' => ''],
+        ['name' => 'via', 'value' => ''],
+        ['name' => 'www-authenticate', 'value' => ''],
+    ];
+
+    private H2HpackDynamicTable $dynamicTable;
+
+    public function __construct(
+        private int $maxTableSize = 4096,
+        private int $maxHeaderListSize = 16384,
+    ) {
+        $this->dynamicTable = new H2HpackDynamicTable($maxTableSize);
+    }
+
+    public function resize(int $maxTableSize): void
+    {
+        if ($maxTableSize < 0) {
+            throw H2Exception::forConnectionError('HPACK table size must not be negative');
+        }
+
+        $this->maxTableSize = $maxTableSize;
+        $this->dynamicTable->setMaxSize($maxTableSize);
+    }
+
+    /**
+     * @return list<array{name: string, value: string}>
+     */
+    public function decode(string $block): array
+    {
+        $headers = [];
+        $offset = 0;
+        $length = strlen($block);
+        $totalSize = 0;
+        $pastFirstHeader = false;
+        $tableSizeUpdates = 0;
+
+        while ($offset < $length) {
+            $byte = ord($block[$offset]);
+
+            if (($byte & 0b1110_0000) === 0b0010_0000) {
+                if ($pastFirstHeader) {
+                    throw H2Exception::forConnectionError('HPACK table size update must appear at block start');
+                }
+
+                $tableSizeUpdates++;
+                if ($tableSizeUpdates > 2) {
+                    throw H2Exception::forConnectionError('HPACK too many dynamic table size updates');
+                }
+
+                [$newSize, $offset] = H2HpackInteger::decode($block, $offset, 5, $length);
+                if ($newSize > $this->maxTableSize) {
+                    throw H2Exception::forConnectionError('HPACK table size update exceeds allowed maximum');
+                }
+
+                $this->dynamicTable->setMaxSize($newSize);
+                continue;
+            }
+
+            $pastFirstHeader = true;
+            $sensitive = false;
+
+            if (($byte & 0b1000_0000) !== 0) {
+                $index = $byte & 0x7F;
+                if ($index < 0x7F) {
+                    $offset++;
+                } else {
+                    [$index, $offset] = H2HpackInteger::decode($block, $offset, 7, $length);
+                }
+
+                $entry = $this->lookupIndex($index);
+                $name = $entry['name'];
+                $value = $entry['value'];
+            } elseif (($byte & 0b0100_0000) !== 0) {
+                $index = $byte & 0x3F;
+                if ($index < 0x3F) {
+                    $offset++;
+                } else {
+                    [$index, $offset] = H2HpackInteger::decode($block, $offset, 6, $length);
+                }
+
+                if ($index > 0) {
+                    $entry = $this->lookupIndex($index);
+                    $name = $entry['name'];
+                } else {
+                    [$name, $offset] = $this->decodeString($block, $offset, $length);
+                }
+
+                [$value, $offset] = $this->decodeString($block, $offset, $length);
+                $this->dynamicTable->insert($name, $value);
+            } elseif (($byte & 0b1111_0000) === 0b0001_0000) {
+                $index = $byte & 0x0F;
+                if ($index < 0x0F) {
+                    $offset++;
+                } else {
+                    [$index, $offset] = H2HpackInteger::decode($block, $offset, 4, $length);
+                }
+
+                if ($index > 0) {
+                    $entry = $this->lookupIndex($index);
+                    $name = $entry['name'];
+                } else {
+                    [$name, $offset] = $this->decodeString($block, $offset, $length);
+                }
+
+                [$value, $offset] = $this->decodeString($block, $offset, $length);
+                $sensitive = true;
+            } else {
+                $index = $byte & 0x0F;
+                if ($index < 0x0F) {
+                    $offset++;
+                } else {
+                    [$index, $offset] = H2HpackInteger::decode($block, $offset, 4, $length);
+                }
+
+                if ($index > 0) {
+                    $entry = $this->lookupIndex($index);
+                    $name = $entry['name'];
+                } else {
+                    [$name, $offset] = $this->decodeString($block, $offset, $length);
+                }
+
+                [$value, $offset] = $this->decodeString($block, $offset, $length);
+            }
+
+            $totalSize += strlen($name) + strlen($value) + 32;
+            if ($totalSize > $this->maxHeaderListSize) {
+                throw H2Exception::forConnectionError('HPACK decoded header list exceeds configured limit');
+            }
+
+            $headers[] = ['name' => $name, 'value' => $value];
+            if ($sensitive) {
+                continue;
+            }
+        }
+
+        return $headers;
+    }
+
+    /**
+     * @return array{string, int}
+     */
+    private function decodeString(string $data, int $offset, int $dataLength): array
+    {
+        if ($offset >= $dataLength) {
+            throw H2Exception::forConnectionError('HPACK string literal is truncated');
+        }
+
+        $huffman = (ord($data[$offset]) & 0b1000_0000) !== 0;
+        [$stringLength, $offset] = H2HpackInteger::decode($data, $offset, 7, $dataLength);
+        if (($offset + $stringLength) > $dataLength) {
+            throw H2Exception::forConnectionError('HPACK string literal is truncated');
+        }
+
+        $stringData = substr($data, $offset, $stringLength);
+        $offset += $stringLength;
+
+        if ($huffman) {
+            $stringData = H2HpackHuffman::decode($stringData);
+        }
+
+        return [$stringData, $offset];
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    private function lookupIndex(int $index): array
+    {
+        if ($index === 0) {
+            throw H2Exception::forConnectionError('HPACK index must be positive');
+        }
+
+        if ($index <= 61) {
+            return self::STATIC_TABLE[$index - 1];
+        }
+
+        $entry = $this->dynamicTable->get($index - 62);
+        if ($entry !== null) {
+            return $entry;
+        }
+
+        throw H2Exception::forConnectionError('HPACK index out of range');
+    }
+}

--- a/lib/swow-library/src/Http/Protocol/H2HpackDynamicTable.php
+++ b/lib/swow-library/src/Http/Protocol/H2HpackDynamicTable.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swow\Http\Protocol;
+
+use function array_slice;
+use function strlen;
+
+final class H2HpackDynamicTable
+{
+    private const ENTRY_OVERHEAD = 32;
+
+    /**
+     * @var list<array{name: string, value: string}>
+     */
+    private array $entries = [];
+
+    private int $head = 0;
+
+    private int $tail = 0;
+
+    private int $size = 0;
+
+    public function __construct(private int $maxSize = 4096)
+    {
+    }
+
+    public function insert(string $name, string $value): void
+    {
+        $entrySize = strlen($name) + strlen($value) + self::ENTRY_OVERHEAD;
+        if ($entrySize > $this->maxSize) {
+            $this->entries = [];
+            $this->head = 0;
+            $this->tail = 0;
+            $this->size = 0;
+            return;
+        }
+
+        while (($this->size + $entrySize) > $this->maxSize && $this->head < $this->tail) {
+            $this->evict();
+        }
+
+        $this->entries[] = ['name' => $name, 'value' => $value];
+        $this->tail++;
+        $this->size += $entrySize;
+
+        if ($this->head > 256) {
+            $this->entries = array_slice($this->entries, $this->head);
+            $this->tail -= $this->head;
+            $this->head = 0;
+        }
+    }
+
+    public function setMaxSize(int $maxSize): void
+    {
+        $this->maxSize = $maxSize;
+        while ($this->size > $this->maxSize && $this->head < $this->tail) {
+            $this->evict();
+        }
+    }
+
+    /**
+     * @return array{name: string, value: string}|null
+     */
+    public function get(int $index): ?array
+    {
+        $logicalCount = $this->tail - $this->head;
+        if ($index >= $logicalCount) {
+            return null;
+        }
+
+        $realIndex = $this->tail - 1 - $index;
+        return $this->entries[$realIndex];
+    }
+
+    public function count(): int
+    {
+        return $this->tail - $this->head;
+    }
+
+    private function evict(): void
+    {
+        if ($this->head >= $this->tail) {
+            return;
+        }
+
+        $entry = $this->entries[$this->head];
+        $this->head++;
+        $this->size -= strlen($entry['name']) + strlen($entry['value']) + self::ENTRY_OVERHEAD;
+    }
+}

--- a/lib/swow-library/src/Http/Protocol/H2HpackHuffman.php
+++ b/lib/swow-library/src/Http/Protocol/H2HpackHuffman.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swow\Http\Protocol;
+
+use function array_shift;
+use function chr;
+use function ord;
+use function str_contains;
+use function strlen;
+
+final class H2HpackHuffman
+{
+    /**
+     * @var list<array{int, int}>
+     */
+    private const CODE_TABLE = [
+        [0x1ff8, 13], [0x7f_ffd8, 23], [0xfff_ffe2, 28], [0xfff_ffe3, 28],
+        [0xfff_ffe4, 28], [0xfff_ffe5, 28], [0xfff_ffe6, 28], [0xfff_ffe7, 28],
+        [0xfff_ffe8, 28], [0xff_ffea, 24], [0x3fff_fffc, 30], [0xfff_ffe9, 28],
+        [0xfff_ffea, 28], [0x3fff_fffd, 30], [0xfff_ffeb, 28], [0xfff_ffec, 28],
+        [0xfff_ffed, 28], [0xfff_ffee, 28], [0xfff_ffef, 28], [0xfff_fff0, 28],
+        [0xfff_fff1, 28], [0xfff_fff2, 28], [0x3fff_fffe, 30], [0xfff_fff3, 28],
+        [0xfff_fff4, 28], [0xfff_fff5, 28], [0xfff_fff6, 28], [0xfff_fff7, 28],
+        [0xfff_fff8, 28], [0xfff_fff9, 28], [0xfff_fffa, 28], [0xfff_fffb, 28],
+        [0x14, 6], [0x3f8, 10], [0x3f9, 10], [0xffa, 12], [0x1ff9, 13], [0x15, 6],
+        [0xf8, 8], [0x7fa, 11], [0x3fa, 10], [0x3fb, 10], [0xf9, 8], [0x7fb, 11],
+        [0xfa, 8], [0x16, 6], [0x17, 6], [0x18, 6], [0x0, 5], [0x1, 5], [0x2, 5],
+        [0x19, 6], [0x1a, 6], [0x1b, 6], [0x1c, 6], [0x1d, 6], [0x1e, 6], [0x1f, 6],
+        [0x5c, 7], [0xfb, 8], [0x7ffc, 15], [0x20, 6], [0xffb, 12], [0x3fc, 10],
+        [0x1ffa, 13], [0x21, 6], [0x5d, 7], [0x5e, 7], [0x5f, 7], [0x60, 7], [0x61, 7],
+        [0x62, 7], [0x63, 7], [0x64, 7], [0x65, 7], [0x66, 7], [0x67, 7], [0x68, 7],
+        [0x69, 7], [0x6a, 7], [0x6b, 7], [0x6c, 7], [0x6d, 7], [0x6e, 7], [0x6f, 7],
+        [0x70, 7], [0x71, 7], [0x72, 7], [0xfc, 8], [0x73, 7], [0xfd, 8], [0x1ffb, 13],
+        [0x7_fff0, 19], [0x1ffc, 13], [0x3ffc, 14], [0x22, 6], [0x7ffd, 15], [0x3, 5],
+        [0x23, 6], [0x4, 5], [0x24, 6], [0x5, 5], [0x25, 6], [0x26, 6], [0x27, 6],
+        [0x6, 5], [0x74, 7], [0x75, 7], [0x28, 6], [0x29, 6], [0x2a, 6], [0x7, 5],
+        [0x2b, 6], [0x76, 7], [0x2c, 6], [0x8, 5], [0x9, 5], [0x2d, 6], [0x77, 7],
+        [0x78, 7], [0x79, 7], [0x7a, 7], [0x7b, 7], [0x7ffe, 15], [0x7fc, 11],
+        [0x3ffd, 14], [0x1ffd, 13], [0xfff_fffc, 28], [0xf_ffe6, 20], [0x3f_ffd2, 22],
+        [0xf_ffe7, 20], [0xf_ffe8, 20], [0x3f_ffd3, 22], [0x3f_ffd4, 22], [0x3f_ffd5, 22],
+        [0x7f_ffd9, 23], [0x3f_ffd6, 22], [0x7f_ffda, 23], [0x7f_ffdb, 23], [0x7f_ffdc, 23],
+        [0x7f_ffdd, 23], [0x7f_ffde, 23], [0xff_ffeb, 24], [0x7f_ffdf, 23], [0xff_ffec, 24],
+        [0xff_ffed, 24], [0x3f_ffd7, 22], [0x7f_ffe0, 23], [0xff_ffee, 24], [0x7f_ffe1, 23],
+        [0x7f_ffe2, 23], [0x7f_ffe3, 23], [0x7f_ffe4, 23], [0x1f_ffdc, 21], [0x3f_ffd8, 22],
+        [0x7f_ffe5, 23], [0x3f_ffd9, 22], [0x7f_ffe6, 23], [0x7f_ffe7, 23], [0xff_ffef, 24],
+        [0x3f_ffda, 22], [0x1f_ffdd, 21], [0xf_ffe9, 20], [0x3f_ffdb, 22], [0x3f_ffdc, 22],
+        [0x7f_ffe8, 23], [0x7f_ffe9, 23], [0x1f_ffde, 21], [0x7f_ffea, 23], [0x3f_ffdd, 22],
+        [0x3f_ffde, 22], [0xff_fff0, 24], [0x1f_ffdf, 21], [0x3f_ffdf, 22], [0x7f_ffeb, 23],
+        [0x7f_ffec, 23], [0x1f_ffe0, 21], [0x1f_ffe1, 21], [0x3f_ffe0, 22], [0x1f_ffe2, 21],
+        [0x7f_ffed, 23], [0x3f_ffe1, 22], [0x7f_ffee, 23], [0x7f_ffef, 23], [0xf_ffea, 20],
+        [0x3f_ffe2, 22], [0x3f_ffe3, 22], [0x3f_ffe4, 22], [0x7f_fff0, 23], [0x3f_ffe5, 22],
+        [0x3f_ffe6, 22], [0x7f_fff1, 23], [0x3ff_ffe0, 26], [0x3ff_ffe1, 26], [0xf_ffeb, 20],
+        [0x7_fff1, 19], [0x3f_ffe7, 22], [0x7f_fff2, 23], [0x3f_ffe8, 22], [0x1ff_ffec, 25],
+        [0x3ff_ffe2, 26], [0x3ff_ffe3, 26], [0x3ff_ffe4, 26], [0x7ff_ffde, 27], [0x7ff_ffdf, 27],
+        [0x3ff_ffe5, 26], [0xff_fff1, 24], [0x1ff_ffed, 25], [0x7_fff2, 19], [0x1f_ffe3, 21],
+        [0x3ff_ffe6, 26], [0x7ff_ffe0, 27], [0x7ff_ffe1, 27], [0x3ff_ffe7, 26], [0x7ff_ffe2, 27],
+        [0xff_fff2, 24], [0x1f_ffe4, 21], [0x1f_ffe5, 21], [0x3ff_ffe8, 26], [0x3ff_ffe9, 26],
+        [0xfff_fffd, 28], [0x7ff_ffe3, 27], [0x7ff_ffe4, 27], [0x7ff_ffe5, 27], [0xf_ffec, 20],
+        [0xff_fff3, 24], [0xf_ffed, 20], [0x1f_ffe6, 21], [0x3f_ffe9, 22], [0x1f_ffe7, 21],
+        [0x1f_ffe8, 21], [0x7f_fff3, 23], [0x3f_ffea, 22], [0x3f_ffeb, 22], [0x1ff_ffee, 25],
+        [0x1ff_ffef, 25], [0xff_fff4, 24], [0xff_fff5, 24], [0x3ff_ffea, 26], [0x7f_fff4, 23],
+        [0x3ff_ffeb, 26], [0x7ff_ffe6, 27], [0x3ff_ffec, 26], [0x3ff_ffed, 26], [0x7ff_ffe7, 27],
+        [0x7ff_ffe8, 27], [0x7ff_ffe9, 27], [0x7ff_ffea, 27], [0x7ff_ffeb, 27], [0xfff_fffe, 28],
+        [0x7ff_ffec, 27], [0x7ff_ffed, 27], [0x7ff_ffee, 27], [0x7ff_ffef, 27], [0x7ff_fff0, 27],
+        [0x3ff_ffee, 26], [0x3fff_ffff, 30],
+    ];
+
+    /**
+     * @var null|array{list<list<array{int, int}>>, list<bool>}
+     */
+    private static ?array $decodeMachine = null;
+
+    public static function decode(string $data): string
+    {
+        [$table, $acceptFlags] = self::getDecodeMachine();
+        $length = strlen($data);
+        $state = 0;
+        $result = '';
+
+        for ($i = 0; $i < $length; $i++) {
+            $byte = ord($data[$i]);
+
+            $highNibble = ($byte >> 4) & 0x0F;
+            $stateTransitions = $table[$state];
+            [$nextState, $emit] = $stateTransitions[$highNibble];
+            if ($emit === 256) {
+                throw H2Exception::forConnectionError('HPACK Huffman EOS is not allowed');
+            }
+            if ($nextState === -1) {
+                throw H2Exception::forConnectionError('HPACK Huffman sequence is invalid');
+            }
+            if ($emit >= 0) {
+                $result .= chr($emit);
+            }
+            $state = $nextState;
+
+            $lowNibble = $byte & 0x0F;
+            [$nextState, $emit] = $table[$state][$lowNibble];
+            if ($emit === 256) {
+                throw H2Exception::forConnectionError('HPACK Huffman EOS is not allowed');
+            }
+            if ($nextState === -1) {
+                throw H2Exception::forConnectionError('HPACK Huffman sequence is invalid');
+            }
+            if ($emit >= 0) {
+                $result .= chr($emit);
+            }
+            $state = $nextState;
+        }
+
+        if ($state !== 0 && !$acceptFlags[$state]) {
+            throw H2Exception::forConnectionError('HPACK Huffman padding is invalid');
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array{list<list<array{int, int}>>, list<bool>}
+     */
+    private static function getDecodeMachine(): array
+    {
+        if (self::$decodeMachine !== null) {
+            return self::$decodeMachine;
+        }
+
+        $trie = self::buildTrie();
+        self::$decodeMachine = self::buildNibbleTable($trie);
+
+        return self::$decodeMachine;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private static function buildTrie(): array
+    {
+        $trie = ['' => -1];
+        for ($sym = 0; $sym <= 256; $sym++) {
+            [$code, $codeLen] = self::CODE_TABLE[$sym];
+            $path = '';
+            for ($bit = $codeLen - 1; $bit >= 0; $bit--) {
+                $path .= (string) (($code >> $bit) & 1);
+                if (!isset($trie[$path])) {
+                    $trie[$path] = -1;
+                }
+            }
+            $trie[$path] = $sym;
+        }
+
+        return $trie;
+    }
+
+    /**
+     * @param array<string, int> $trie
+     * @return array{list<list<array{int, int}>>, list<bool>}
+     */
+    private static function buildNibbleTable(array $trie): array
+    {
+        $stateMap = ['' => 0];
+        $statePaths = [''];
+        $states = [[]];
+        $queue = [''];
+        $stateId = 1;
+
+        while ($queue !== []) {
+            $bitPath = array_shift($queue);
+            $currentStateId = $stateMap[$bitPath];
+            $transitions = [];
+
+            for ($nibble = 0; $nibble < 16; $nibble++) {
+                $path = $bitPath;
+                $emit = -1;
+                for ($bit = 3; $bit >= 0; $bit--) {
+                    $path .= (string) (($nibble >> $bit) & 1);
+                    if (isset($trie[$path]) && $trie[$path] >= 0) {
+                        $sym = $trie[$path];
+                        if ($sym === 256) {
+                            $transitions[] = [-1, 256];
+                            continue 2;
+                        }
+
+                        $emit = $sym;
+                        $path = '';
+                    }
+                }
+
+                if (!isset($trie[$path])) {
+                    $transitions[] = [-1, -1];
+                    continue;
+                }
+
+                if (!isset($stateMap[$path])) {
+                    $stateMap[$path] = $stateId++;
+                    $statePaths[] = $path;
+                    $states[] = [];
+                    $queue[] = $path;
+                }
+
+                $transitions[] = [$stateMap[$path], $emit];
+            }
+
+            $states[$currentStateId] = $transitions;
+        }
+
+        $acceptFlags = [];
+        foreach ($statePaths as $path) {
+            $acceptFlags[] = $path === '' || (strlen($path) <= 7 && !str_contains($path, '0'));
+        }
+
+        return [$states, $acceptFlags];
+    }
+}

--- a/lib/swow-library/src/Http/Protocol/H2HpackInteger.php
+++ b/lib/swow-library/src/Http/Protocol/H2HpackInteger.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swow\Http\Protocol;
+
+use function ord;
+use function strlen;
+
+use const PHP_INT_MAX;
+
+final class H2HpackInteger
+{
+    /**
+     * @return array{int, int}
+     */
+    public static function decode(string $data, int $offset, int $prefixBits, ?int $length = null): array
+    {
+        $length ??= strlen($data);
+        if ($offset >= $length) {
+            throw H2Exception::forConnectionError('HPACK integer is truncated');
+        }
+
+        $maxPrefix = (1 << $prefixBits) - 1;
+        $value = ord($data[$offset]) & $maxPrefix;
+        $offset++;
+
+        if ($value < $maxPrefix) {
+            return [$value, $offset];
+        }
+
+        $shift = 0;
+        do {
+            if ($offset >= $length) {
+                throw H2Exception::forConnectionError('HPACK integer is truncated');
+            }
+
+            $byte = ord($data[$offset]);
+            $offset++;
+
+            if ($shift > 56) {
+                throw H2Exception::forConnectionError('HPACK integer overflow');
+            }
+
+            $increment = ($byte & 0x7F) << $shift;
+            if ($value > (PHP_INT_MAX - $increment)) {
+                throw H2Exception::forConnectionError('HPACK integer overflow');
+            }
+
+            $value += $increment;
+            $shift += 7;
+        } while (($byte & 0x80) !== 0);
+
+        return [$value, $offset];
+    }
+}

--- a/lib/swow-library/src/Http/Protocol/H2PendingFrameQueue.php
+++ b/lib/swow-library/src/Http/Protocol/H2PendingFrameQueue.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swow\Http\Protocol;
+
+final class H2PendingFrameQueue
+{
+    /** @var list<H2Frame> */
+    private array $controlFrames = [];
+
+    /** @var list<H2Frame> */
+    private array $requestStartFrames = [];
+
+    /** @var array<int, list<H2Frame>> */
+    private array $streamFrames = [];
+
+    /** @var list<int> */
+    private array $streamOrder = [];
+
+    public function defer(H2Frame $frame): void
+    {
+        if ($this->isControlFrame($frame)) {
+            $this->controlFrames[] = $frame;
+
+            return;
+        }
+
+        if ($frame->type === H2Frame::TYPE_HEADERS) {
+            $this->requestStartFrames[] = $frame;
+
+            return;
+        }
+
+        $this->streamFrames[$frame->streamId] ??= [];
+        $this->streamFrames[$frame->streamId][] = $frame;
+        $this->trackStream($frame->streamId);
+    }
+
+    public function shift(): ?H2Frame
+    {
+        $frame = array_shift($this->controlFrames);
+        if ($frame instanceof H2Frame) {
+            return $frame;
+        }
+
+        $frame = array_shift($this->requestStartFrames);
+        if ($frame instanceof H2Frame) {
+            return $frame;
+        }
+
+        return $this->shiftStreamFrame();
+    }
+
+    public function takeControlFrame(callable $isControlFrame): ?H2Frame
+    {
+        $frame = array_shift($this->controlFrames);
+
+        return $frame instanceof H2Frame ? $frame : null;
+    }
+
+    public function takeRequestStartFrame(): ?H2Frame
+    {
+        $frame = array_shift($this->requestStartFrames);
+
+        return $frame instanceof H2Frame ? $frame : null;
+    }
+
+    public function hasRequestStartFrameForStream(int $streamId): bool
+    {
+        foreach ($this->requestStartFrames as $frame) {
+            if ($frame->streamId === $streamId) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function takeFrameForStream(int $streamId, callable $isControlFrame): ?H2Frame
+    {
+        $frame = array_shift($this->controlFrames);
+        if ($frame instanceof H2Frame) {
+            return $frame;
+        }
+
+        $frames = $this->streamFrames[$streamId] ?? [];
+        $frame = array_shift($frames);
+        if ($frame instanceof H2Frame) {
+            $this->storeStreamFrames($streamId, $frames);
+
+            return $frame;
+        }
+
+        return null;
+    }
+
+    private function shiftStreamFrame(): ?H2Frame
+    {
+        while ($this->streamOrder !== []) {
+            $streamId = array_shift($this->streamOrder);
+            if (!is_int($streamId)) {
+                continue;
+            }
+
+            $frames = $this->streamFrames[$streamId] ?? [];
+            $frame = array_shift($frames);
+            if (!$frame instanceof H2Frame) {
+                unset($this->streamFrames[$streamId]);
+                continue;
+            }
+
+            $this->storeStreamFrames($streamId, $frames);
+
+            return $frame;
+        }
+
+        return null;
+    }
+
+    /** @param list<H2Frame> $frames */
+    private function storeStreamFrames(int $streamId, array $frames): void
+    {
+        if ($frames === []) {
+            unset($this->streamFrames[$streamId]);
+
+            return;
+        }
+
+        $this->streamFrames[$streamId] = $frames;
+        $this->streamOrder[] = $streamId;
+    }
+
+    private function trackStream(int $streamId): void
+    {
+        if (isset($this->streamFrames[$streamId]) && count($this->streamFrames[$streamId]) === 1) {
+            $this->streamOrder[] = $streamId;
+        }
+    }
+
+    private function isControlFrame(H2Frame $frame): bool
+    {
+        return match ($frame->type) {
+            H2Frame::TYPE_SETTINGS,
+            H2Frame::TYPE_PING,
+            H2Frame::TYPE_GOAWAY,
+            H2Frame::TYPE_WINDOW_UPDATE,
+            H2Frame::TYPE_RST_STREAM => true,
+            default => false,
+        };
+    }
+}

--- a/lib/swow-library/src/Http/Protocol/H2StreamStateMatrix.php
+++ b/lib/swow-library/src/Http/Protocol/H2StreamStateMatrix.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swow\Http\Protocol;
+
+final class H2StreamStateMatrix
+{
+    public static function assertCanSend(int $streamId, ?string $state): void
+    {
+        if ($state === H2Connection::STREAM_STATE_HALF_CLOSED_LOCAL || $state === H2Connection::STREAM_STATE_CLOSED) {
+            throw H2Exception::forStreamError(
+                $streamId,
+                'Cannot send on locally closed stream',
+                H2Exception::ERROR_STREAM_CLOSED
+            );
+        }
+    }
+
+    public static function assertCanReceiveData(int $streamId, ?string $state): void
+    {
+        if ($state === H2Connection::STREAM_STATE_HALF_CLOSED_REMOTE || $state === H2Connection::STREAM_STATE_CLOSED) {
+            throw H2Exception::forStreamError(
+                $streamId,
+                'Cannot receive DATA on remotely closed stream',
+                H2Exception::ERROR_STREAM_CLOSED
+            );
+        }
+    }
+
+    public static function validateInboundFrame(
+        H2Frame $frame,
+        ?string $state,
+        bool $isClosed,
+        bool $isIdleDataFrame,
+        bool $isIdleContinuationFrame,
+    ): H2Frame {
+        if (
+            ($frame->type === H2Frame::TYPE_DATA ||
+             $frame->type === H2Frame::TYPE_HEADERS ||
+             $frame->type === H2Frame::TYPE_CONTINUATION) &&
+            ($frame->streamId < 1 || ($frame->streamId % 2) === 0)
+        ) {
+            throw H2Exception::forConnectionError('Request frame must use an odd positive stream ID');
+        }
+
+        if ($isIdleDataFrame || $isIdleContinuationFrame) {
+            throw H2Exception::forConnectionError('Frame received for idle stream');
+        }
+
+        if (
+            $frame->streamId > 0 &&
+            ($isClosed || $state === H2Connection::STREAM_STATE_HALF_CLOSED_REMOTE) &&
+            ($frame->type === H2Frame::TYPE_DATA ||
+             $frame->type === H2Frame::TYPE_HEADERS ||
+             $frame->type === H2Frame::TYPE_CONTINUATION)
+        ) {
+            throw H2Exception::forStreamError(
+                $frame->streamId,
+                'Frame received for closed stream',
+                H2Exception::ERROR_STREAM_CLOSED
+            );
+        }
+
+        return $frame;
+    }
+
+    public static function stateAfterRemoteOpened(bool $ended): string
+    {
+        return $ended
+            ? H2Connection::STREAM_STATE_HALF_CLOSED_REMOTE
+            : H2Connection::STREAM_STATE_OPEN;
+    }
+
+    public static function stateAfterRemoteEnded(?string $state): string
+    {
+        if ($state === H2Connection::STREAM_STATE_HALF_CLOSED_LOCAL) {
+            return H2Connection::STREAM_STATE_CLOSED;
+        }
+
+        return H2Connection::STREAM_STATE_HALF_CLOSED_REMOTE;
+    }
+
+    public static function stateAfterLocalEnded(?string $state): string
+    {
+        if ($state === H2Connection::STREAM_STATE_HALF_CLOSED_REMOTE) {
+            return H2Connection::STREAM_STATE_CLOSED;
+        }
+
+        return H2Connection::STREAM_STATE_HALF_CLOSED_LOCAL;
+    }
+}

--- a/lib/swow-library/src/Psr7/Server/EventDriver.php
+++ b/lib/swow-library/src/Psr7/Server/EventDriver.php
@@ -30,6 +30,7 @@ use Swow\Psr7\Psr7;
 use Swow\SocketException;
 use Swow\WebSocket\Opcode as WebSocketOpcode;
 use Swow\WebSocket\WebSocket;
+use Throwable;
 use TypeError;
 
 use function in_array;
@@ -47,10 +48,10 @@ class EventDriver
     /** @var Closure(Server): void */
     protected Closure $startHandler;
 
-    /** @var Closure(ServerConnection): void */
+    /** @var Closure(ServerConnection|H2ServerConnection): void */
     protected Closure $connectionHandler;
 
-    /** @var Closure(ServerConnection, ServerRequestPlusInterface): mixed */
+    /** @var Closure(ServerConnection|H2ServerConnection, ServerRequestPlusInterface): mixed */
     protected Closure $requestHandler;
 
     /** @var Closure(ServerConnection, ServerRequestPlusInterface, int): mixed */
@@ -59,10 +60,10 @@ class EventDriver
     /** @var Closure(ServerConnection, WebSocketFrameInterface): mixed */
     protected Closure $messageHandler;
 
-    /** @var Closure(ServerConnection): void */
+    /** @var Closure(ServerConnection|H2ServerConnection): void */
     protected Closure $closeHandler;
 
-    /** @var Closure(ServerConnection, Exception): void */
+    /** @var Closure(ServerConnection|H2ServerConnection, Throwable): void */
     protected Closure $exceptionHandler;
 
     public function __construct(?Server $server = null)
@@ -78,7 +79,7 @@ class EventDriver
         return $new;
     }
 
-    /** @param callable(ServerConnection): void $handler */
+    /** @param callable(ServerConnection|H2ServerConnection): void $handler */
     public function withConnectionHandler(callable $handler): static
     {
         $new = clone $this;
@@ -86,7 +87,7 @@ class EventDriver
         return $new;
     }
 
-    /** @param callable(ServerConnection, ServerRequestPlusInterface): mixed $handler */
+    /** @param callable(ServerConnection|H2ServerConnection, ServerRequestPlusInterface): mixed $handler */
     public function withRequestHandler(callable $handler): static
     {
         $new = clone $this;
@@ -102,7 +103,7 @@ class EventDriver
         return $new;
     }
 
-    /** @param callable(ServerConnection): void $handler */
+    /** @param callable(ServerConnection|H2ServerConnection): void $handler */
     public function withCloseHandler(callable $handler): static
     {
         $new = clone $this;
@@ -110,11 +111,11 @@ class EventDriver
         return $new;
     }
 
-    /** @param callable(ServerConnection, Exception): void $handler */
+    /** @param callable(ServerConnection|H2ServerConnection, Throwable): void $handler */
     public function withExceptionHandler(callable $handler): static
     {
         $new = clone $this;
-        $this->exceptionHandler = $handler;
+        $new->exceptionHandler = Closure::fromCallable($handler);
         return $new;
     }
 
@@ -134,92 +135,17 @@ class EventDriver
 
         while (true) {
             try {
-                $connection = null;
                 $connection = $server->acceptConnection();
-                if ($connectionHandler !== null) {
-                    $connectionHandler($connection);
-                }
-                Coroutine::run(static function () use ($connection, $requestHandler, $upgradeHandler, $messageHandler, $closeHandler, $exceptionHandler): void {
-                    try {
-                        while (true) {
-                            $request = null;
-                            try {
-                                /** @var ServerRequestPlusInterface $request */
-                                $request = $connection->recvHttpRequest();
-                                if ($requestHandler) {
-                                    $upgradeType = UpgradeType::UPGRADE_TYPE_NONE;
-                                    if ($upgradeHandler !== null || $messageHandler !== null) {
-                                        $upgradeType = Psr7::detectUpgradeType($request);
-                                        if ($upgradeType !== UpgradeType::UPGRADE_TYPE_NONE) {
-                                            if (($upgradeType & UpgradeType::UPGRADE_TYPE_WEBSOCKET) === 0) {
-                                                throw new HttpProtocolException(HttpStatus::BAD_REQUEST, 'Unsupported Upgrade Type');
-                                            }
-                                            if ($upgradeHandler !== null) {
-                                                $upgradeResponse = $upgradeHandler($connection, $request, $upgradeType);
-                                                if ($upgradeResponse !== null && !($upgradeResponse instanceof ResponseInterface)) {
-                                                    $upgradeResponse = static::solveUpgradeResponse($upgradeResponse);
-                                                }
-                                            }
-                                        }
-                                    }
-                                    if ($upgradeType === UpgradeType::UPGRADE_TYPE_NONE) {
-                                        $response = $requestHandler($connection, $request);
-                                        if ($response !== null) {
-                                            if ($response instanceof ResponseInterface) {
-                                                $connection->sendHttpResponse($response);
-                                            } elseif (is_array($response)) {
-                                                $connection->respond(...$response);
-                                            } else {
-                                                $connection->respond($response);
-                                            }
-                                        }
-                                    } elseif ($upgradeType & UpgradeType::UPGRADE_TYPE_WEBSOCKET) {
-                                        $connection->upgradeToWebSocket($request, $upgradeResponse ?? null);
-                                        $request = null;
-                                        while (true) {
-                                            $frame = $connection->recvWebSocketFrame();
-                                            $opcode = $frame->getOpcode();
-                                            switch ($opcode) {
-                                                case WebSocketOpcode::PING:
-                                                    $connection->send(WebSocket::PONG_FRAME);
-                                                    break;
-                                                case WebSocketOpcode::PONG:
-                                                    break;
-                                                case WebSocketOpcode::CLOSE:
-                                                    break 3;
-                                                default:
-                                                    $reply = $messageHandler($connection, $frame);
-                                                    if ($reply instanceof WebSocketFrameInterface) {
-                                                        $connection->sendWebSocketFrame($reply);
-                                                    } elseif (Swow\Debug\isStrictStringable($reply)) {
-                                                        $connection->sendWebSocketFrame(
-                                                            Psr7::createWebSocketTextFrame(
-                                                                payloadData: $reply
-                                                            )
-                                                        );
-                                                    }
-                                            }
-                                        }
-                                    }
-                                }
-                            } catch (HttpProtocolException $exception) {
-                                $connection->error($exception->getCode(), $exception->getMessage(), close: true);
-                                break;
-                            }
-                            if (!$connection->shouldKeepAlive()) {
-                                break;
-                            }
-                        }
-                    } catch (Exception $exception) {
-                        if ($exceptionHandler !== null) {
-                            $exceptionHandler($connection, $exception);
-                        }
-                    } finally {
-                        if ($closeHandler !== null) {
-                            $closeHandler($connection);
-                        }
-                        $connection->close();
-                    }
+                $handler = $this->createConnectionHandler(
+                    $connectionHandler,
+                    $requestHandler,
+                    $upgradeHandler,
+                    $messageHandler,
+                    $closeHandler,
+                    $exceptionHandler
+                );
+                Coroutine::run(function () use ($connection, $handler): void {
+                    $handler->handle($connection);
                 });
             } catch (CoroutineException|SocketException $exception) {
                 if (in_array($exception->getCode(), [Errno::EMFILE, Errno::ENFILE, Errno::ENOMEM], true)) {
@@ -278,5 +204,31 @@ class EventDriver
                 break;
         }
         return $upgradeResponse;
+    }
+
+    /**
+     * @param ?Closure(ServerConnection|H2ServerConnection): void $connectionHandler
+     * @param ?Closure(ServerConnection|H2ServerConnection, ServerRequestPlusInterface): mixed $requestHandler
+     * @param ?Closure(ServerConnection, ServerRequestPlusInterface, int): mixed $upgradeHandler
+     * @param ?Closure(ServerConnection, WebSocketFrameInterface): mixed $messageHandler
+     * @param ?Closure(ServerConnection|H2ServerConnection): void $closeHandler
+     * @param ?Closure(ServerConnection|H2ServerConnection, Throwable): void $exceptionHandler
+     */
+    protected function createConnectionHandler(
+        ?Closure $connectionHandler,
+        ?Closure $requestHandler,
+        ?Closure $upgradeHandler,
+        ?Closure $messageHandler,
+        ?Closure $closeHandler,
+        ?Closure $exceptionHandler,
+    ): EventDriverConnectionHandler {
+        return new EventDriverConnectionHandler(
+            $connectionHandler,
+            $requestHandler,
+            $upgradeHandler,
+            $messageHandler,
+            $closeHandler,
+            $exceptionHandler,
+        );
     }
 }

--- a/lib/swow-library/src/Psr7/Server/EventDriverConnectionHandler.php
+++ b/lib/swow-library/src/Psr7/Server/EventDriverConnectionHandler.php
@@ -1,0 +1,245 @@
+<?php
+
+/**
+ * This file is part of Swow
+ *
+ * @link    https://github.com/swow/swow
+ * @contact twosee <twosee@php.net>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code
+ */
+
+declare(strict_types=1);
+
+namespace Swow\Psr7\Server;
+
+use Closure;
+use Exception;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Swow;
+use Swow\Http\Protocol\ProtocolException as HttpProtocolException;
+use Swow\Http\Protocol\H2Connection;
+use Swow\Psr7\Message\ServerRequestPlusInterface;
+use Swow\Psr7\Message\UpgradeType;
+use Swow\Psr7\Message\WebSocketFrameInterface;
+use Swow\Psr7\Psr7;
+use Swow\Http\Status as HttpStatus;
+use Swow\Socket;
+use Swow\WebSocket\Opcode as WebSocketOpcode;
+use Swow\WebSocket\WebSocket;
+use Throwable;
+
+use function strlen;
+use function str_starts_with;
+
+class EventDriverConnectionHandler
+{
+    /**
+     * @param ?Closure(ServerConnection|H2ServerConnection): void $connectionHandler
+     * @param ?Closure(ServerConnection|H2ServerConnection, ServerRequestPlusInterface): mixed $requestHandler
+     * @param ?Closure(ServerConnection, ServerRequestPlusInterface, int): mixed $upgradeHandler
+     * @param ?Closure(ServerConnection, WebSocketFrameInterface): mixed $messageHandler
+     * @param ?Closure(ServerConnection|H2ServerConnection): void $closeHandler
+     * @param ?Closure(ServerConnection|H2ServerConnection, Throwable): void $exceptionHandler
+     */
+    public function __construct(
+        private ?Closure $connectionHandler,
+        private ?Closure $requestHandler,
+        private ?Closure $upgradeHandler,
+        private ?Closure $messageHandler,
+        private ?Closure $closeHandler,
+        private ?Closure $exceptionHandler,
+    ) {
+    }
+
+    public function handle(ServerConnection|H2ServerConnection $connection): void
+    {
+        $runtimeConnection = $connection instanceof ServerConnection
+            ? $this->detectDirectH2Connection($connection) ?? $connection
+            : $connection;
+
+        try {
+            if ($this->connectionHandler !== null) {
+                ($this->connectionHandler)($runtimeConnection);
+            }
+
+            if ($runtimeConnection instanceof H2ServerConnection) {
+                $this->handleH2Connection($runtimeConnection);
+                return;
+            }
+
+            $upgradedConnection = $this->handleHttpConnection($runtimeConnection);
+            if ($upgradedConnection instanceof H2ServerConnection) {
+                $runtimeConnection = $upgradedConnection;
+            }
+        } catch (Throwable $exception) {
+            if ($this->exceptionHandler !== null) {
+                ($this->exceptionHandler)($runtimeConnection, $exception);
+            }
+        } finally {
+            if ($this->closeHandler !== null) {
+                ($this->closeHandler)($runtimeConnection);
+            }
+            $runtimeConnection->close();
+        }
+    }
+
+    private function handleH2Connection(H2ServerConnection $connection): void
+    {
+        if ($this->requestHandler === null) {
+            return;
+        }
+
+        $connection->serve(function ($request, int $streamId) use ($connection) {
+            return ($this->requestHandler)($connection, $request);
+        });
+    }
+
+    protected function detectDirectH2Connection(ServerConnection $connection): ?H2ServerConnection
+    {
+        $negotiatedProtocol = $this->getNegotiatedAlpnProtocol($connection);
+        if ($negotiatedProtocol === 'h2') {
+            return $this->createH2ServerConnectionFromSocket($connection, $connection->getServerParams());
+        }
+        if ($negotiatedProtocol !== null) {
+            return null;
+        }
+
+        $preface = $this->peekConnectionPreface($connection);
+        if (!$this->isDirectH2PrefaceCandidate($preface)) {
+            return null;
+        }
+
+        return $this->createH2ServerConnectionFromSocket($connection, $connection->getServerParams());
+    }
+
+    protected function getNegotiatedAlpnProtocol(ServerConnection $connection): ?string
+    {
+        if (!method_exists($connection, 'getNegotiatedAlpnProtocol')) {
+            return null;
+        }
+
+        $protocol = $connection->getNegotiatedAlpnProtocol();
+        return $protocol === '' ? null : $protocol;
+    }
+
+    protected function peekConnectionPreface(ServerConnection $connection): string
+    {
+        return $connection->peekString(strlen(H2Connection::CLIENT_PREFACE), $connection->getServer()->getRecvMessageTimeout());
+    }
+
+    protected function isDirectH2PrefaceCandidate(string $preface): bool
+    {
+        return $preface !== '' && str_starts_with(H2Connection::CLIENT_PREFACE, $preface);
+    }
+
+    protected function createH2ServerConnectionFromSocket(Socket $socket, array $serverParams = []): H2ServerConnection
+    {
+        return H2ServerConnection::wrap($socket, $serverParams);
+    }
+
+    private function handleHttpConnection(ServerConnection $connection): ?H2ServerConnection
+    {
+        while (true) {
+            $request = null;
+            try {
+                /** @var ServerRequestPlusInterface $request */
+                $request = $connection->recvHttpRequest();
+                if ($this->requestHandler !== null) {
+                    $upgradeType = Psr7::detectUpgradeType($request);
+                    if (($upgradeType & UpgradeType::UPGRADE_TYPE_H2C) !== 0) {
+                        return $this->handleH2cUpgrade($connection, $request);
+                    }
+
+                    $upgradeType = UpgradeType::UPGRADE_TYPE_NONE;
+                    if ($this->upgradeHandler !== null || $this->messageHandler !== null) {
+                        $upgradeType = Psr7::detectUpgradeType($request);
+                        if ($upgradeType !== UpgradeType::UPGRADE_TYPE_NONE) {
+                            if (($upgradeType & UpgradeType::UPGRADE_TYPE_WEBSOCKET) === 0) {
+                                throw new HttpProtocolException(HttpStatus::BAD_REQUEST, 'Unsupported Upgrade Type');
+                            }
+                            if ($this->upgradeHandler !== null) {
+                                $upgradeResponse = ($this->upgradeHandler)($connection, $request, $upgradeType);
+                                if ($upgradeResponse !== null && !($upgradeResponse instanceof ResponseInterface)) {
+                                    $upgradeResponse = H2ResponseNormalizer::normalize($upgradeResponse);
+                                }
+                            }
+                        }
+                    }
+                    if ($upgradeType === UpgradeType::UPGRADE_TYPE_NONE) {
+                        $response = ($this->requestHandler)($connection, $request);
+                        if ($response !== null) {
+                            if ($response instanceof ResponseInterface) {
+                                $connection->sendHttpResponse($response);
+                            } elseif (is_array($response)) {
+                                $connection->respond(...$response);
+                            } else {
+                                $connection->respond($response);
+                            }
+                        }
+                    } elseif ($upgradeType & UpgradeType::UPGRADE_TYPE_WEBSOCKET) {
+                        $connection->upgradeToWebSocket($request, $upgradeResponse ?? null);
+                        $request = null;
+                        while (true) {
+                            $frame = $connection->recvWebSocketFrame();
+                            $opcode = $frame->getOpcode();
+                            switch ($opcode) {
+                                case WebSocketOpcode::PING:
+                                    $connection->send(WebSocket::PONG_FRAME);
+                                    break;
+                                case WebSocketOpcode::PONG:
+                                    break;
+                                case WebSocketOpcode::CLOSE:
+                                    break 3;
+                                default:
+                                    $reply = ($this->messageHandler)($connection, $frame);
+                                    if ($reply instanceof WebSocketFrameInterface) {
+                                        $connection->sendWebSocketFrame($reply);
+                                    } elseif (Swow\Debug\isStrictStringable($reply)) {
+                                        $connection->sendWebSocketFrame(
+                                            Psr7::createWebSocketTextFrame(
+                                                payloadData: $reply
+                                            )
+                                        );
+                                    }
+                            }
+                        }
+                    }
+                }
+            } catch (HttpProtocolException $exception) {
+                $connection->error($exception->getCode(), $exception->getMessage(), close: true);
+                break;
+            }
+            if (!$connection->shouldKeepAlive()) {
+                break;
+            }
+        }
+
+        return null;
+    }
+
+    private function handleH2cUpgrade(ServerConnection $connection, ServerRequestInterface $request): H2ServerConnection
+    {
+        $settingsPayload = H2UpgradeBridge::decodeSettingsPayload($request);
+        $connection->sendHttpHeader(
+            HttpStatus::SWITCHING_PROTOCOLS,
+            headers: [
+                'Connection' => 'Upgrade',
+                'Upgrade' => 'h2c',
+            ]
+        );
+
+        $h2Connection = $this->createH2ServerConnectionFromSocket($connection, $connection->getServerParams());
+        $h2Connection->getConnection()->initializeForUpgrade(peerSettingsPayload: $settingsPayload);
+        H2UpgradeBridge::serveUpgradeRequest(
+            $h2Connection,
+            $request,
+            fn(ServerRequestInterface $request, int $streamId): mixed => ($this->requestHandler)($h2Connection, $request),
+        );
+
+        return $h2Connection;
+    }
+
+}

--- a/lib/swow-library/src/Psr7/Server/H2ResponseEnvelope.php
+++ b/lib/swow-library/src/Psr7/Server/H2ResponseEnvelope.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swow\Psr7\Server;
+
+use Psr\Http\Message\ResponseInterface;
+
+final class H2ResponseEnvelope
+{
+    public function __construct(
+        public ResponseInterface $response,
+        private H2Trailers $trailers,
+    ) {}
+
+    /**
+     * @param array<string, array<string>|string>|H2Trailers $trailers
+     */
+    public static function from(ResponseInterface $response, array|H2Trailers $trailers = []): self
+    {
+        return new self(
+            $response,
+            $trailers instanceof H2Trailers ? $trailers : H2Trailers::fromArray($trailers)
+        );
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public function trailersMap(): array
+    {
+        return $this->trailers->toArray();
+    }
+
+    public function trailersObject(): H2Trailers
+    {
+        return $this->trailers;
+    }
+}

--- a/lib/swow-library/src/Psr7/Server/H2ResponseNormalizer.php
+++ b/lib/swow-library/src/Psr7/Server/H2ResponseNormalizer.php
@@ -1,0 +1,188 @@
+<?php
+
+/**
+ * This file is part of Swow
+ *
+ * @link    https://github.com/swow/swow
+ * @contact twosee <twosee@php.net>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code
+ */
+
+declare(strict_types=1);
+
+namespace Swow\Psr7\Server;
+
+use Psr\Http\Message\ResponseInterface;
+use Swow\Http\Status as HttpStatus;
+use Swow\Psr7\Psr7;
+use TypeError;
+
+use function get_debug_type;
+use function is_array;
+use function is_int;
+use function array_is_list;
+use function sprintf;
+use function Swow\Debug\isStrictStringable;
+
+final class H2ResponseNormalizer
+{
+    public static function normalize(mixed $response): H2ResponseEnvelope
+    {
+        if ($response instanceof H2ResponseEnvelope) {
+            return $response;
+        }
+
+        if ($response instanceof ResponseInterface) {
+            return H2ResponseEnvelope::from($response);
+        }
+
+        if (is_array($response) && !self::isList($response) && self::looksLikeNamedResponseMap($response)) {
+            return self::normalizeNamedResponseMap($response);
+        }
+
+        $statusCode = HttpStatus::OK;
+        $headers = [];
+        $body = '';
+        $trailers = [];
+        $headerArraySeen = false;
+        $responseArgs = is_array($response) ? $response : [$response];
+        if (is_array($response) && self::isList($response) && $responseArgs !== []) {
+            $trailers = self::extractTrailingTrailerArray($responseArgs);
+        }
+        foreach ($responseArgs as $responseArg) {
+            if (isStrictStringable($responseArg)) {
+                $body = (string) $responseArg;
+                continue;
+            }
+            if (is_int($responseArg)) {
+                $statusCode = $responseArg;
+                continue;
+            }
+            if (is_array($responseArg)) {
+                if (!$headerArraySeen) {
+                    $headers = $responseArg;
+                    $headerArraySeen = true;
+                    continue;
+                }
+
+                $trailers = $responseArg;
+                continue;
+            }
+
+            throw new TypeError(sprintf('Unsupported argument type %s', get_debug_type($responseArg)));
+        }
+
+        return H2ResponseEnvelope::from(
+            Psr7::createResponse(
+                code: $statusCode,
+                headers: $headers,
+                body: $body
+            ),
+            H2Trailers::fromArray($trailers)
+        );
+    }
+
+    /**
+     * @param list<mixed> $responseArgs
+     * @return array<string, array<string>|string>
+     */
+    private static function extractTrailingTrailerArray(array &$responseArgs): array
+    {
+        $lastIndex = array_key_last($responseArgs);
+        $lastValue = $lastIndex !== null ? $responseArgs[$lastIndex] : null;
+        if (!is_array($lastValue) || !self::looksLikeTrailerMap($lastValue)) {
+            return [];
+        }
+
+        unset($responseArgs[$lastIndex]);
+        $responseArgs = array_values($responseArgs);
+
+        return $lastValue;
+    }
+
+    /**
+     * @param array<mixed> $headers
+     */
+    private static function looksLikeTrailerMap(array $headers): bool
+    {
+        foreach ($headers as $name => $_value) {
+            if (!is_string($name)) {
+                return false;
+            }
+        }
+
+        return $headers !== [];
+    }
+
+    /**
+     * @param array<mixed> $response
+     */
+    private static function looksLikeNamedResponseMap(array $response): bool
+    {
+        foreach ($response as $key => $_value) {
+            if (!is_string($key)) {
+                return false;
+            }
+
+            if (!in_array($key, ['status', 'headers', 'body', 'trailers'], true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array{status?: mixed, headers?: mixed, body?: mixed, trailers?: mixed} $response
+     */
+    private static function normalizeNamedResponseMap(array $response): H2ResponseEnvelope
+    {
+        $status = $response['status'] ?? HttpStatus::OK;
+        if (!is_int($status)) {
+            throw new TypeError(sprintf('Unsupported argument type %s', get_debug_type($status)));
+        }
+
+        $headers = $response['headers'] ?? [];
+        if (!is_array($headers)) {
+            throw new TypeError(sprintf('Unsupported argument type %s', get_debug_type($headers)));
+        }
+
+        $body = $response['body'] ?? '';
+        if (!isStrictStringable($body)) {
+            throw new TypeError(sprintf('Unsupported argument type %s', get_debug_type($body)));
+        }
+
+        $trailers = $response['trailers'] ?? [];
+        if (!is_array($trailers)) {
+            throw new TypeError(sprintf('Unsupported argument type %s', get_debug_type($trailers)));
+        }
+
+        return H2ResponseEnvelope::from(
+            Psr7::createResponse(
+                code: $status,
+                headers: $headers,
+                body: (string) $body
+            ),
+            H2Trailers::fromArray($trailers)
+        );
+    }
+
+    /**
+     * @param array<mixed> $value
+     */
+    private static function isList(array $value): bool
+    {
+        $expectedIndex = 0;
+        foreach ($value as $key => $_item) {
+            if ($key !== $expectedIndex) {
+                return false;
+            }
+
+            $expectedIndex++;
+        }
+
+        return true;
+    }
+}

--- a/lib/swow-library/src/Psr7/Server/H2ServerConnection.php
+++ b/lib/swow-library/src/Psr7/Server/H2ServerConnection.php
@@ -1,0 +1,423 @@
+<?php
+
+/**
+ * This file is part of Swow
+ *
+ * @link    https://github.com/swow/swow
+ * @contact twosee <twosee@php.net>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code
+ */
+
+declare(strict_types=1);
+
+namespace Swow\Psr7\Server;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Swow\Http\Protocol\H2Connection;
+use Swow\Http\Protocol\H2Exception;
+use Swow\Http\Protocol\H2Frame;
+use Swow\Http\Protocol\H2Hpack;
+use Swow\Http\Protocol\H2Headers;
+use Swow\Http\Protocol\H2HeaderBlock;
+use Swow\Http\Message\ServerRequestEntity;
+use Swow\Psr7\Psr7;
+use Swow\Socket;
+
+use function substr;
+use function strlen;
+
+final class H2ServerConnection extends Socket
+{
+    use ServerParamsTrait;
+
+    public const REQUEST_TRAILERS_ATTRIBUTE = 'trailers';
+
+    private H2Hpack|null $hpack = null;
+
+    private Socket $managedSocket;
+
+    public function __construct(
+        int $type = Socket::TYPE_TCP,
+        private H2Connection|null $connection = null,
+    ) {
+        parent::__construct($type);
+        $this->connection ??= new H2Connection($this);
+        $this->managedSocket = $this->connection->getSocket();
+    }
+
+    /**
+     * @param array<string, mixed> $serverParams
+     */
+    public static function wrap(Socket $socket, array $serverParams = []): static
+    {
+        $connection = new static(connection: new H2Connection($socket));
+        $connection->setServerParams($serverParams);
+
+        return $connection;
+    }
+
+    public function getConnection(): H2Connection
+    {
+        return $this->connection ??= new H2Connection($this);
+    }
+
+    public function getSocket(): Socket
+    {
+        return $this->managedSocket;
+    }
+
+    public function readClientPreface(?int $timeout = null): void
+    {
+        $this->getConnection()->readClientPreface($timeout);
+    }
+
+    public function initialize(?int $timeout = null, array $settings = []): void
+    {
+        $this->getConnection()->initialize($timeout, $settings);
+    }
+
+    /**
+     * @param array<int, array{name: string, value: string}|array{0: string, 1: string}> $headers
+     */
+    public function recvRequestEntityFromHeaders(array $headers): ServerRequestEntity
+    {
+        return H2Headers::createServerRequestEntity($headers, $this->serverParams);
+    }
+
+    /**
+     * @param array<int, array{name: string, value: string}|array{0: string, 1: string}> $headers
+     */
+    public function recvRequestFromHeaders(array $headers): ServerRequestInterface
+    {
+        return Psr7::createServerRequestFromEntity($this->recvRequestEntityFromHeaders($headers));
+    }
+
+    public function recvRequestFromHeaderBlock(string $headerBlock): ServerRequestInterface
+    {
+        return $this->recvRequestFromHeaders($this->getHpack()->decode($headerBlock));
+    }
+
+    /**
+     * @return array{streamId: int, request: ServerRequestInterface}
+     */
+    public function recvStreamRequest(?int $timeout = null): array
+    {
+        $streamRequest = $this->tryRecvStreamRequest($timeout);
+        if ($streamRequest !== null) {
+            return $streamRequest;
+        }
+
+        throw H2Exception::forConnectionError('No more request streams are allowed on this connection');
+    }
+
+    /**
+     * @return array{streamId: int, request: ServerRequestInterface}|null
+     */
+    public function tryRecvStreamRequest(?int $timeout = null): ?array
+    {
+        $connection = $this->getConnection();
+
+        try {
+            $headerBlock = $connection->readHeaderBlockOrNull($timeout);
+            if ($headerBlock === null) {
+                return null;
+            }
+
+            $request = $this->recvRequestFromHeaderBlock($headerBlock->getBuffer());
+            $streamId = $headerBlock->getStreamId();
+            if (($headerBlock->getFlags() & H2Frame::FLAG_END_STREAM) === 0) {
+                $bodyWithTrailers = $connection->readRequestBodyWithTrailers($streamId, $timeout);
+                $request->getBody()->write($bodyWithTrailers['body']);
+                if ($bodyWithTrailers['trailers'] instanceof H2HeaderBlock) {
+                    $request = $request->withAttribute(
+                        self::REQUEST_TRAILERS_ATTRIBUTE,
+                        H2Trailers::fromArray(
+                            H2Headers::createTrailerMap(
+                                $this->getHpack()->decode($bodyWithTrailers['trailers']->getBuffer())
+                            )
+                        )
+                    );
+                }
+            }
+
+            return [
+                'streamId' => $streamId,
+                'request' => $request,
+            ];
+        } catch (H2Exception $exception) {
+            if (!$exception->isConnectionLevel() && $exception->getStreamId() > 0) {
+                $connection->sendRstStream($exception->getStreamId(), $exception->getH2ErrorCode(), $timeout);
+            }
+
+            throw $exception;
+        }
+    }
+
+    public function recvRequest(?int $timeout = null): ServerRequestInterface
+    {
+        return $this->recvStreamRequest($timeout)['request'];
+    }
+
+    /**
+     * @param array{timeout?: ?int, settings?: array<int, int>, limit?: ?int}|array{} $options
+     */
+    public function serve(callable $handler, array $options = []): int
+    {
+        $timeout = $options['timeout'] ?? null;
+        $settings = $options['settings'] ?? [];
+        $limit = $options['limit'] ?? null;
+
+        $this->readClientPreface($timeout);
+        $this->initialize($timeout, $settings);
+
+        return $this->handleRequests($handler, $timeout, $limit);
+    }
+
+    public function handleOneRequest(callable $handler, ?int $timeout = null): int
+    {
+        $streamRequest = $this->recvStreamRequest($timeout);
+        $streamId = $streamRequest['streamId'];
+        try {
+            $response = H2ResponseNormalizer::normalize($handler($streamRequest['request'], $streamId));
+        } catch (H2Exception $exception) {
+            if (!$exception->isConnectionLevel()) {
+                $this->getConnection()->sendRstStream($exception->getStreamId() > 0 ? $exception->getStreamId() : $streamId, $exception->getH2ErrorCode(), $timeout);
+            }
+
+            throw $exception;
+        }
+        $this->sendResponseEnvelope($streamId, $response, $timeout);
+
+        return $streamId;
+    }
+
+    public function handleRequests(callable $handler, ?int $timeout = null, ?int $limit = null): int
+    {
+        $handled = 0;
+        while ($limit === null || $handled < $limit) {
+            try {
+                $streamRequest = $this->tryRecvStreamRequest($timeout);
+                if ($streamRequest === null) {
+                    break;
+                }
+
+                $streamId = $streamRequest['streamId'];
+                $response = H2ResponseNormalizer::normalize($handler($streamRequest['request'], $streamId));
+                $this->sendResponseEnvelope($streamId, $response, $timeout);
+                $handled++;
+            } catch (H2Exception $exception) {
+                if (!$exception->isConnectionLevel() && isset($streamRequest)) {
+                    $targetStreamId = $exception->getStreamId() > 0 ? $exception->getStreamId() : $streamRequest['streamId'];
+                    if ($targetStreamId > 0) {
+                        $this->getConnection()->sendRstStream($targetStreamId, $exception->getH2ErrorCode(), $timeout);
+                    }
+                }
+
+                if ($exception->isConnectionLevel()) {
+                    throw $exception;
+                }
+            }
+        }
+
+        return $handled;
+    }
+
+    public function sendResponse(int $streamId, ResponseInterface $response, ?int $timeout = null): void
+    {
+        $this->sendResponseEnvelope($streamId, H2ResponseEnvelope::from($response), $timeout);
+    }
+
+    /**
+     * @param array<string, array<string>|string> $trailers
+     */
+    public function sendTrailedResponse(
+        int $streamId,
+        ResponseInterface $response,
+        array $trailers,
+        ?int $timeout = null
+    ): void
+    {
+        $this->sendResponseEnvelope($streamId, H2ResponseEnvelope::from($response, $trailers), $timeout);
+    }
+
+    private function sendResponseEnvelope(int $streamId, H2ResponseEnvelope $responseEnvelope, ?int $timeout = null): void
+    {
+        $response = $responseEnvelope->response;
+        $body = (string) $response->getBody();
+        $headers = $response->getHeaders();
+        $trailers = $responseEnvelope->trailersMap();
+        if ($body === '' && $trailers === []) {
+            $this->sendResponseHeaders($streamId, $response->getStatusCode(), $headers, true, $timeout);
+
+            return;
+        }
+
+        $this->sendResponseHeaders($streamId, $response->getStatusCode(), $headers, $body === '' && $trailers === [], $timeout);
+        if ($body !== '') {
+            $this->sendResponseData($streamId, $body, $trailers === [], $timeout);
+        }
+        if ($trailers !== []) {
+            $this->sendResponseTrailers($streamId, $trailers, $timeout);
+        }
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public static function getRequestTrailers(ServerRequestInterface $request): array
+    {
+        return self::requestTrailersObject($request)->toArray();
+    }
+
+    public static function requestTrailersObject(ServerRequestInterface $request): H2Trailers
+    {
+        $trailers = $request->getAttribute(self::REQUEST_TRAILERS_ATTRIBUTE, null);
+        if ($trailers instanceof H2Trailers) {
+            return $trailers;
+        }
+
+        return is_array($trailers) ? H2Trailers::fromArray($trailers) : H2Trailers::empty();
+    }
+
+    /**
+     * @param array<string, array<string>|string> $headers
+     */
+    public function sendResponseHeaders(
+        int $streamId,
+        int $statusCode,
+        array $headers = [],
+        bool $endStream = false,
+        ?int $timeout = null
+    ): void {
+        $connection = $this->getConnection();
+        $connection->assertCanUseResponseStream($streamId);
+        $headerBlock = H2Headers::encodeResponseHeaders($statusCode, $headers);
+        $headerBlockLength = strlen($headerBlock);
+        $maxFrameSize = $connection->getLocalMaxFrameSize();
+        $offset = 0;
+        $firstChunk = true;
+        while ($offset < $headerBlockLength) {
+            $chunk = substr($headerBlock, $offset, $maxFrameSize);
+            $offset += strlen($chunk);
+            $isLast = $offset >= $headerBlockLength;
+            $flags = $isLast ? H2Frame::FLAG_END_HEADERS : 0;
+            if ($firstChunk && $endStream) {
+                $flags |= H2Frame::FLAG_END_STREAM;
+            }
+
+            $connection->sendFrame(
+                new H2Frame(
+                    $firstChunk ? H2Frame::TYPE_HEADERS : H2Frame::TYPE_CONTINUATION,
+                    $flags,
+                    $streamId,
+                    $chunk
+                ),
+                $timeout
+            );
+            $firstChunk = false;
+        }
+
+        if ($endStream) {
+            $connection->noteResponseEnd($streamId);
+        }
+    }
+
+    public function sendResponseData(
+        int $streamId,
+        string $data,
+        bool $endStream = false,
+        ?int $timeout = null
+    ): void {
+        $connection = $this->getConnection();
+        $connection->assertCanUseResponseStream($streamId);
+        $maxFrameSize = $connection->getLocalMaxFrameSize();
+        $length = strlen($data);
+        $offset = 0;
+        while ($offset < $length) {
+            $availableWindow = $connection->getAvailableSendWindow($streamId);
+            if ($availableWindow === 0) {
+                $connection->waitForSendWindow($streamId, 1, $timeout);
+                $connection->assertCanUseResponseStream($streamId);
+                $availableWindow = $connection->getAvailableSendWindow($streamId);
+            }
+
+            $chunkSize = min($maxFrameSize, $availableWindow, $length - $offset);
+            $chunk = substr($data, $offset, $chunkSize);
+            $offset += strlen($chunk);
+            $isLast = $offset >= $length;
+
+            $connection->sendFrame(
+                new H2Frame(
+                    H2Frame::TYPE_DATA,
+                    $endStream && $isLast ? H2Frame::FLAG_END_STREAM : 0,
+                    $streamId,
+                    $chunk
+                ),
+                $timeout
+            );
+            $connection->consumeSendWindow($streamId, $chunkSize);
+            if ($endStream && $isLast) {
+                $connection->noteResponseEnd($streamId);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, array<string>|string> $trailers
+     */
+    public function sendResponseTrailers(int $streamId, array $trailers, ?int $timeout = null): void
+    {
+        $connection = $this->getConnection();
+        $connection->assertCanUseResponseStream($streamId);
+        $headerBlock = H2Headers::encodeTrailerHeaders($trailers);
+        $headerBlockLength = strlen($headerBlock);
+        $maxFrameSize = $connection->getLocalMaxFrameSize();
+        $offset = 0;
+        $firstChunk = true;
+        while ($offset < $headerBlockLength) {
+            $chunk = substr($headerBlock, $offset, $maxFrameSize);
+            $offset += strlen($chunk);
+            $isLast = $offset >= $headerBlockLength;
+            $flags = $isLast ? (H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM) : 0;
+            $connection->sendFrame(
+                new H2Frame(
+                    $firstChunk ? H2Frame::TYPE_HEADERS : H2Frame::TYPE_CONTINUATION,
+                    $flags,
+                    $streamId,
+                    $chunk
+                ),
+                $timeout
+            );
+            $firstChunk = false;
+        }
+
+        $connection->noteResponseEnd($streamId);
+    }
+
+    public function goAway(
+        int $errorCode = H2Exception::ERROR_NO_ERROR,
+        int $lastStreamId = 0,
+        string $debugData = '',
+        ?int $timeout = null
+    ): void {
+        $this->getConnection()->goAway($errorCode, $lastStreamId, $debugData, $timeout);
+    }
+
+    private function getHpack(): H2Hpack
+    {
+        return $this->hpack ??= new H2Hpack();
+    }
+
+    public function close(): bool
+    {
+        $socket = $this->getSocket();
+        if ($socket === $this) {
+            return parent::close();
+        }
+
+        return $socket->close();
+    }
+}

--- a/lib/swow-library/src/Psr7/Server/H2ServerConnectionFactory.php
+++ b/lib/swow-library/src/Psr7/Server/H2ServerConnectionFactory.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 
 namespace Swow\Psr7\Server;
 
-interface ServerConnectionFactoryInterface
+final class H2ServerConnectionFactory implements ServerConnectionFactoryInterface
 {
-    public function createServerConnection(Server $server): ServerConnection|H2ServerConnection;
+    public function createServerConnection(Server $server): ServerConnection|H2ServerConnection
+    {
+        return new H2ServerConnection($server->getSimpleType());
+    }
 }

--- a/lib/swow-library/src/Psr7/Server/H2Trailers.php
+++ b/lib/swow-library/src/Psr7/Server/H2Trailers.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swow\Psr7\Server;
+
+final class H2Trailers
+{
+    /** @var array<string, list<string>> */
+    private array $headers;
+
+    /**
+     * @param array<string, array<string>|string> $headers
+     */
+    private function __construct(array $headers)
+    {
+        $normalized = [];
+        foreach ($headers as $name => $value) {
+            $values = is_array($value) ? $value : [$value];
+            $normalized[$name] = array_map(static fn(mixed $single): string => (string) $single, $values);
+        }
+
+        $this->headers = $normalized;
+    }
+
+    public static function empty(): self
+    {
+        return new self([]);
+    }
+
+    /**
+     * @param array<string, array<string>|string> $headers
+     */
+    public static function fromArray(array $headers): self
+    {
+        return new self($headers);
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public function toArray(): array
+    {
+        return $this->headers;
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->headers === [];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function get(string $name): array
+    {
+        return $this->headers[$name] ?? [];
+    }
+}

--- a/lib/swow-library/src/Psr7/Server/H2UpgradeBridge.php
+++ b/lib/swow-library/src/Psr7/Server/H2UpgradeBridge.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * This file is part of Swow
+ *
+ * @link    https://github.com/swow/swow
+ * @contact twosee <twosee@php.net>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code
+ */
+
+declare(strict_types=1);
+
+namespace Swow\Psr7\Server;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Swow\Http\Protocol\H2Exception;
+use Swow\Http\Status as HttpStatus;
+use Swow\Http\Protocol\ProtocolException as HttpProtocolException;
+
+use function base64_decode;
+use function str_repeat;
+use function strlen;
+use function strtr;
+use function trim;
+
+final class H2UpgradeBridge
+{
+    public static function decodeSettingsPayload(ServerRequestInterface $request): string
+    {
+        $encoded = trim($request->getHeaderLine('HTTP2-Settings'));
+        if ($encoded === '') {
+            throw new HttpProtocolException(HttpStatus::BAD_REQUEST, 'Missing HTTP2-Settings header for h2c upgrade');
+        }
+
+        $normalized = strtr($encoded, '-_', '+/');
+        $normalized .= str_repeat('=', (4 - (strlen($normalized) % 4)) % 4);
+        $payload = base64_decode($normalized, true);
+        if (!is_string($payload) || (strlen($payload) % 6) !== 0) {
+            throw new HttpProtocolException(HttpStatus::BAD_REQUEST, 'Invalid HTTP2-Settings header payload');
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param array{timeout?: ?int, settings?: array<int, int>, limit?: ?int}|array{} $options
+     */
+    public static function serveUpgradeRequest(
+        H2ServerConnection $connection,
+        ServerRequestInterface $request,
+        callable $handler,
+        array $options = []
+    ): int {
+        $timeout = $options['timeout'] ?? null;
+        $limit = $options['limit'] ?? null;
+        $streamId = 1;
+
+        $connection->getConnection()->beginUpgradedRequestStream($streamId, true);
+        try {
+            $response = H2ResponseNormalizer::normalize($handler($request, $streamId));
+        } catch (H2Exception $exception) {
+            if (!$exception->isConnectionLevel()) {
+                $targetStreamId = $exception->getStreamId() > 0 ? $exception->getStreamId() : $streamId;
+                $connection->getConnection()->sendRstStream($targetStreamId, $exception->getH2ErrorCode(), $timeout);
+            }
+
+            throw $exception;
+        }
+
+        $connection->sendTrailedResponse($streamId, $response->response, $response->trailersMap(), $timeout);
+        if ($limit === 1) {
+            return 1;
+        }
+
+        $remaining = $limit === null ? null : max(0, $limit - 1);
+
+        return 1 + $connection->handleRequests($handler, $timeout, $remaining);
+    }
+}

--- a/lib/swow-library/src/Psr7/Server/Server.php
+++ b/lib/swow-library/src/Psr7/Server/Server.php
@@ -58,16 +58,18 @@ class Server extends Socket
         return $this;
     }
 
-    public function acceptConnection(?int $timeout = null): ServerConnection
+    public function acceptConnection(?int $timeout = null): ServerConnection|H2ServerConnection
     {
         while (true) {
             $connection = $this->serverConnectionFactory->createServerConnection($this);
             $this->acceptTo($connection, $timeout);
             try {
-                $connection->addServerParams([
-                    'remote_addr' => $connection->getPeerAddress(),
-                    'remote_port' => $connection->getPeerPort(),
-                ]);
+                if ($connection instanceof ServerConnection || $connection instanceof H2ServerConnection) {
+                    $connection->addServerParams([
+                        'remote_addr' => $connection->getPeerAddress(),
+                        'remote_port' => $connection->getPeerPort(),
+                    ]);
+                }
             } catch (SocketException) {
                 /* FIXME: workaround for ENOTCONN error.
                  * getpeername() may return ENOTCONN in some edge cases,
@@ -76,11 +78,35 @@ class Server extends Socket
                  * we ignore it and continue to accept next connection for now. */
                 continue;
             }
-            $this->online($connection);
+            if ($connection instanceof ServerConnection) {
+                $this->online($connection);
+            }
             break;
         }
 
         return $connection;
+    }
+
+    /**
+     * @param array{acceptTimeout?: ?int, timeout?: ?int, settings?: array<int, int>, limit?: ?int}|array{} $options
+     */
+    public function handleH2Connection(callable $handler, array $options = []): int
+    {
+        $acceptTimeout = $options['acceptTimeout'] ?? null;
+        $timeout = $options['timeout'] ?? null;
+        $settings = $options['settings'] ?? [];
+        $limit = $options['limit'] ?? null;
+
+        $connection = $this->acceptConnection($acceptTimeout);
+        if (!$connection instanceof H2ServerConnection) {
+            throw new \RuntimeException('Accepted connection is not an H2 server connection');
+        }
+
+        return $connection->serve($handler, [
+            'timeout' => $timeout,
+            'settings' => $settings,
+            'limit' => $limit,
+        ]);
     }
 
     protected const BROADCAST_FLAG_NONE = 0;

--- a/lib/swow-library/src/Psr7/Server/ServerConnectionManagerTrait.php
+++ b/lib/swow-library/src/Psr7/Server/ServerConnectionManagerTrait.php
@@ -19,7 +19,7 @@ use WeakMap;
 
 trait ServerConnectionManagerTrait
 {
-    /** @var WeakMap<ServerConnection, bool> */
+    /** @var WeakMap<ServerConnection|H2ServerConnection, bool> */
     protected WeakMap $connections;
 
     protected function __constructServerConnectionManager(): void
@@ -32,7 +32,7 @@ trait ServerConnectionManagerTrait
         return new ServerConnectionIterator($this->connections->getIterator());
     }
 
-    /** @param Closure(ServerConnection): bool $filter */
+    /** @param Closure(ServerConnection|H2ServerConnection): bool $filter */
     public function getFilteredConnections(Closure $filter)
     {
         return new FilteredServerConnectionIterator($this->connections->getIterator(), $filter);
@@ -40,24 +40,32 @@ trait ServerConnectionManagerTrait
 
     public function getHttpConnections(): ServerConnectionIteratorInterface
     {
-        return $this->getFilteredConnections(static function (ServerConnection $connection) {
+        return $this->getFilteredConnections(static function (ServerConnection|H2ServerConnection $connection) {
+            if (!$connection instanceof ServerConnection) {
+                return false;
+            }
+
             return $connection->getProtocolType() === $connection::PROTOCOL_TYPE_HTTP;
         });
     }
 
     public function getWebSocketConnections(): ServerConnectionIteratorInterface
     {
-        return $this->getFilteredConnections(static function (ServerConnection $connection) {
+        return $this->getFilteredConnections(static function (ServerConnection|H2ServerConnection $connection) {
+            if (!$connection instanceof ServerConnection) {
+                return false;
+            }
+
             return $connection->getProtocolType() === $connection::PROTOCOL_TYPE_WEBSOCKET;
         });
     }
 
-    protected function online(ServerConnection $connection): void
+    protected function online(ServerConnection|H2ServerConnection $connection): void
     {
         $this->connections[$connection] = $connection->getId();
     }
 
-    public function offline(ServerConnection $connection): void
+    public function offline(ServerConnection|H2ServerConnection $connection): void
     {
         unset($this->connections[$connection]);
     }

--- a/lib/swow-library/src/Psr7/Utils/CreatorTrait.php
+++ b/lib/swow-library/src/Psr7/Utils/CreatorTrait.php
@@ -337,6 +337,9 @@ trait CreatorTrait
             $uploadedFiles = null;
         }
         if ($serverRequest instanceof ServerRequestPlusInterface) {
+            if (method_exists($serverRequest, 'setProtocolVersion')) {
+                $serverRequest->setProtocolVersion($serverRequestEntity->protocolVersion);
+            }
             if ($queryParams) {
                 $serverRequest->setQueryParams($queryParams);
             }

--- a/lib/swow-library/tests/Http/Protocol/H2ConnectionTest.php
+++ b/lib/swow-library/tests/Http/Protocol/H2ConnectionTest.php
@@ -1,0 +1,528 @@
+<?php
+
+/**
+ * This file is part of Swow
+ *
+ * @link    https://github.com/swow/swow
+ * @contact twosee <twosee@php.net>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code
+ */
+
+declare(strict_types=1);
+
+namespace Swow\Tests\Http\Protocol;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Swow\Http\Protocol\H2Connection;
+use Swow\Http\Protocol\H2Exception;
+use Swow\Http\Protocol\H2Frame;
+use Swow\Socket;
+
+use function pack;
+
+/**
+ * @internal
+ */
+#[CoversClass(H2Connection::class)]
+final class H2ConnectionTest extends TestCase
+{
+    public function testValidateFrameAcceptsEmptySettingsAck(): void
+    {
+        $connection = new H2Connection(new Socket(Socket::TYPE_TCP));
+        $frame = new H2Frame(H2Frame::TYPE_SETTINGS, H2Frame::FLAG_ACK, 0, '');
+
+        $validated = $connection->validateFrame($frame);
+
+        $this->assertSame($frame, $validated);
+    }
+
+    public function testValidateFrameRejectsSettingsAckWithPayload(): void
+    {
+        $connection = new H2Connection(new Socket(Socket::TYPE_TCP));
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('SETTINGS ACK frame must not contain a payload');
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_SETTINGS, H2Frame::FLAG_ACK, 0, 'x'));
+    }
+
+    public function testValidateFrameRejectsPingPayloadLengthNotEqualToEight(): void
+    {
+        $connection = new H2Connection(new Socket(Socket::TYPE_TCP));
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('PING payload length must be exactly 8');
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_PING, 0, 0, 'short'));
+    }
+
+    public function testValidateFrameRejectsGoAwayPayloadShorterThanEight(): void
+    {
+        $connection = new H2Connection(new Socket(Socket::TYPE_TCP));
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('GOAWAY payload length must be at least 8');
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_GOAWAY, 0, 0, 'short'));
+    }
+
+    public function testValidateFrameRejectsWindowUpdateIncrementZero(): void
+    {
+        $connection = new H2Connection(new Socket(Socket::TYPE_TCP));
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('WINDOW_UPDATE increment must not be 0');
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 1, pack('N', 0)));
+    }
+
+    public function testValidateFrameAcceptsValidWindowUpdate(): void
+    {
+        $connection = new H2Connection(new Socket(Socket::TYPE_TCP));
+        $frame = new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 1, pack('N', 1024));
+
+        $validated = $connection->validateFrame($frame);
+
+        $this->assertSame($frame, $validated);
+    }
+
+    public function testValidateFrameAppliesInitialWindowSizeSetting(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            public function exposeStreamReceiveWindow(int $streamId): int
+            {
+                return $this->streamReceiveWindows[$streamId] ?? $this->streamInitialWindowSize;
+            }
+        };
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_SETTINGS, 0, 0, pack('nN', 0x4, 1024)));
+
+        $this->assertSame(1024, $connection->exposeStreamReceiveWindow(99));
+    }
+
+    public function testValidateFrameRejectsInitialWindowSizeGreaterThanAllowed(): void
+    {
+        $connection = new H2Connection(new Socket(Socket::TYPE_TCP));
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('SETTINGS_INITIAL_WINDOW_SIZE exceeds maximum allowed value');
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_SETTINGS, 0, 0, pack('nN', 0x4, H2Frame::MAX_WINDOW_SIZE + 1)));
+    }
+
+    public function testValidateFrameAppliesMaxFrameSizeSetting(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            public function exposeLocalMaxFrameSize(): int
+            {
+                return $this->localMaxFrameSize;
+            }
+        };
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_SETTINGS, 0, 0, pack('nN', 0x5, 32768)));
+
+        $this->assertSame(32768, $connection->exposeLocalMaxFrameSize());
+    }
+
+    public function testValidateFrameRejectsInvalidMaxFrameSizeSetting(): void
+    {
+        $connection = new H2Connection(new Socket(Socket::TYPE_TCP));
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('SETTINGS_MAX_FRAME_SIZE out of allowed range');
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_SETTINGS, 0, 0, pack('nN', 0x5, H2Frame::DEFAULT_MAX_FRAME_SIZE - 1)));
+    }
+
+    public function testValidateFrameAppliesConnectionLevelWindowUpdateToSendWindow(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            public function exposeConnectionSendWindow(): int
+            {
+                return $this->connectionSendWindow;
+            }
+        };
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 0, pack('N', 1024)));
+
+        $this->assertSame(H2Connection::DEFAULT_INITIAL_WINDOW_SIZE + 1024, $connection->exposeConnectionSendWindow());
+    }
+
+    public function testValidateFrameAppliesStreamLevelWindowUpdateToSendWindow(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            public function exposeStreamSendWindow(int $streamId): int
+            {
+                return $this->streamSendWindows[$streamId] ?? self::DEFAULT_INITIAL_WINDOW_SIZE;
+            }
+        };
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 3, pack('N', 2048)));
+
+        $this->assertSame(H2Connection::DEFAULT_INITIAL_WINDOW_SIZE + 2048, $connection->exposeStreamSendWindow(3));
+    }
+
+    public function testValidateFrameRejectsWindowUpdateWhenConnectionSendWindowOverflows(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->connectionSendWindow = H2Frame::MAX_WINDOW_SIZE;
+            }
+        };
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Connection send window exceeds maximum allowed value');
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 0, pack('N', 1)));
+    }
+
+    public function testValidateFrameRejectsWindowUpdateWhenStreamSendWindowOverflows(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->streamSendWindows[5] = H2Frame::MAX_WINDOW_SIZE;
+            }
+        };
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Stream send window exceeds maximum allowed value');
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 5, pack('N', 1)));
+    }
+
+    public function testValidateFrameAppliesInitialWindowSizeSettingToNewStreamSendWindow(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            public function exposeStreamSendWindow(int $streamId): int
+            {
+                return $this->streamSendWindows[$streamId] ?? $this->streamSendInitialWindowSize;
+            }
+        };
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_SETTINGS, 0, 0, pack('nN', 0x4, 1024)));
+
+        $this->assertSame(1024, $connection->exposeStreamSendWindow(11));
+    }
+
+    public function testValidateFrameAdjustsExistingStreamSendWindowsWhenInitialWindowSizeChanges(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->streamSendWindows[7] = 32_768;
+            }
+
+            public function exposeStreamSendWindow(int $streamId): int
+            {
+                return $this->streamSendWindows[$streamId] ?? $this->streamSendInitialWindowSize;
+            }
+        };
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_SETTINGS, 0, 0, pack('nN', 0x4, 70_000)));
+
+        $this->assertSame(37_233, $connection->exposeStreamSendWindow(7));
+    }
+
+    public function testValidateFrameRejectsInitialWindowSizeWhenAdjustedStreamSendWindowOverflows(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->streamSendWindows[9] = H2Frame::MAX_WINDOW_SIZE;
+            }
+        };
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Adjusted stream send window exceeds maximum allowed value');
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_SETTINGS, 0, 0, pack('nN', 0x4, H2Frame::MAX_WINDOW_SIZE)));
+    }
+
+    public function testSendRstStreamWritesExpectedFrame(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+
+        $connection->sendRstStream(3, H2Exception::ERROR_CANCEL);
+
+        $this->assertCount(1, $connection->frames);
+        $this->assertSame(H2Frame::TYPE_RST_STREAM, $connection->frames[0]->type);
+        $this->assertSame(3, $connection->frames[0]->streamId);
+        $this->assertSame(pack('N', H2Exception::ERROR_CANCEL), $connection->frames[0]->payload);
+    }
+
+    public function testValidateFrameAppliesGoAwayLastAllowedStreamId(): void
+    {
+        $connection = new H2Connection(new Socket(Socket::TYPE_TCP));
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_GOAWAY, 0, 0, pack('NN', 1, H2Exception::ERROR_NO_ERROR)));
+
+        $this->assertTrue($connection->hasReceivedGoAway());
+        $this->assertSame(1, $connection->getLastAllowedStreamId());
+    }
+
+    public function testValidateFrameMarksStreamClosedAfterReceivingRstStream(): void
+    {
+        $connection = new H2Connection(new Socket(Socket::TYPE_TCP));
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_RST_STREAM, 0, 5, pack('N', H2Exception::ERROR_CANCEL)));
+
+        $this->assertTrue($connection->isStreamClosed(5));
+    }
+
+    public function testValidateFrameAllowsRepeatedRstStreamForClosedStream(): void
+    {
+        $connection = new H2Connection(new Socket(Socket::TYPE_TCP));
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_RST_STREAM, 0, 5, pack('N', H2Exception::ERROR_CANCEL)));
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_RST_STREAM, 0, 5, pack('N', H2Exception::ERROR_CANCEL)));
+
+        $this->assertTrue($connection->isStreamClosed(5));
+    }
+
+    public function testValidateFrameRejectsWindowUpdateForClosedStream(): void
+    {
+        $connection = new H2Connection(new Socket(Socket::TYPE_TCP));
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_RST_STREAM, 0, 5, pack('N', H2Exception::ERROR_CANCEL)));
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('WINDOW_UPDATE received for closed stream');
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 5, pack('N', 1024)));
+    }
+
+    public function testValidateFrameAllowsWindowUpdateForHalfClosedRemoteStream(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+        };
+        $connection->frames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82"),
+        ];
+
+        $connection->readHeaderBlock();
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 1, pack('N', 1024)));
+
+        $this->assertSame(H2Connection::STREAM_STATE_HALF_CLOSED_REMOTE, $connection->getStreamState(1));
+        $this->assertSame(H2Connection::DEFAULT_INITIAL_WINDOW_SIZE + 1024, $connection->getStreamSendWindow(1));
+    }
+
+    public function testValidateFrameClosesHalfClosedRemoteStreamAfterRstStream(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+        };
+        $connection->frames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82"),
+        ];
+
+        $connection->readHeaderBlock();
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_RST_STREAM, 0, 1, pack('N', H2Exception::ERROR_CANCEL)));
+
+        $this->assertTrue($connection->isStreamClosed(1));
+        $this->assertSame(H2Connection::STREAM_STATE_CLOSED, $connection->getStreamState(1));
+    }
+
+    public function testValidateFrameAllowsGoAwayWhileHalfClosedRemoteStateIsPreserved(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+        };
+        $connection->frames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82"),
+        ];
+
+        $connection->readHeaderBlock();
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_GOAWAY, 0, 0, pack('NN', 1, H2Exception::ERROR_NO_ERROR)));
+
+        $this->assertTrue($connection->hasReceivedGoAway());
+        $this->assertSame(H2Connection::STREAM_STATE_HALF_CLOSED_REMOTE, $connection->getStreamState(1));
+    }
+
+    public function testValidateFrameRejectsDataForClosedStream(): void
+    {
+        $connection = new H2Connection(new Socket(Socket::TYPE_TCP));
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_RST_STREAM, 0, 5, pack('N', H2Exception::ERROR_CANCEL)));
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Frame received for closed stream');
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_DATA, 0, 5, 'a'));
+    }
+
+    public function testValidateFrameRejectsHeadersForClosedStream(): void
+    {
+        $connection = new H2Connection(new Socket(Socket::TYPE_TCP));
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_RST_STREAM, 0, 7, pack('N', H2Exception::ERROR_CANCEL)));
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Frame received for closed stream');
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS, 7, "\x82"));
+    }
+
+    public function testValidateFrameRejectsHeadersOnEvenRequestStream(): void
+    {
+        $connection = new H2Connection(new Socket(Socket::TYPE_TCP));
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Request frame must use an odd positive stream ID');
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS, 2, "\x82"));
+    }
+
+    public function testValidateFrameRejectsDataOnEvenRequestStream(): void
+    {
+        $connection = new H2Connection(new Socket(Socket::TYPE_TCP));
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Request frame must use an odd positive stream ID');
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_DATA, 0, 2, 'a'));
+    }
+
+    public function testValidateFrameRejectsContinuationOnStreamZero(): void
+    {
+        $connection = new H2Connection(new Socket(Socket::TYPE_TCP));
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Request frame must use an odd positive stream ID');
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_CONTINUATION, 0, 0, 'a'));
+    }
+
+    public function testValidateFrameRejectsDataForIdleStream(): void
+    {
+        $connection = new H2Connection(new Socket(Socket::TYPE_TCP));
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Frame received for idle stream');
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_DATA, 0, 1, 'a'));
+    }
+
+    public function testValidateFrameRejectsContinuationForIdleStream(): void
+    {
+        $connection = new H2Connection(new Socket(Socket::TYPE_TCP));
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Frame received for idle stream');
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_CONTINUATION, 0, 1, 'a'));
+    }
+
+    public function testValidateFrameAllowsDataForExistingRequestStream(): void
+    {
+        $connection = new H2Connection(new Socket(Socket::TYPE_TCP));
+        $connection->markRequestStreamProcessed(1);
+
+        $frame = $connection->validateFrame(new H2Frame(H2Frame::TYPE_DATA, 0, 1, 'a'));
+
+        $this->assertSame(H2Frame::TYPE_DATA, $frame->type);
+        $this->assertSame(1, $frame->streamId);
+    }
+
+    public function testValidateFrameRejectsPriorityOnStreamZero(): void
+    {
+        $connection = new H2Connection(new Socket(Socket::TYPE_TCP));
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('PRIORITY frame must use a positive stream ID');
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_PRIORITY, 0, 0, '12345'));
+    }
+
+    public function testValidateFrameRejectsPriorityWithInvalidPayloadLength(): void
+    {
+        $connection = new H2Connection(new Socket(Socket::TYPE_TCP));
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('PRIORITY payload length must be exactly 5');
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_PRIORITY, 0, 3, '1234'));
+    }
+
+    public function testValidateFrameRejectsClientPushPromise(): void
+    {
+        $connection = new H2Connection(new Socket(Socket::TYPE_TCP));
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Client must not send PUSH_PROMISE frames');
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_PUSH_PROMISE, 0, 3, '1234'));
+    }
+
+    public function testReadHeaderBlockMarksRemoteHalfClosedWhenEndStreamIsSet(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+        };
+        $connection->frames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82"),
+        ];
+
+        $connection->readHeaderBlock();
+
+        $this->assertSame(H2Connection::STREAM_STATE_HALF_CLOSED_REMOTE, $connection->getStreamState(1));
+    }
+}

--- a/lib/swow-library/tests/Http/Protocol/H2FlowControlTest.php
+++ b/lib/swow-library/tests/Http/Protocol/H2FlowControlTest.php
@@ -1,0 +1,233 @@
+<?php
+
+/**
+ * This file is part of Swow
+ *
+ * @link    https://github.com/swow/swow
+ * @contact twosee <twosee@php.net>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code
+ */
+
+declare(strict_types=1);
+
+namespace Swow\Tests\Http\Protocol;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Swow\Http\Protocol\H2Connection;
+use Swow\Http\Protocol\H2Exception;
+use Swow\Http\Protocol\H2Frame;
+use Swow\Socket;
+
+/**
+ * @internal
+ */
+#[CoversClass(H2Connection::class)]
+#[CoversClass(H2Frame::class)]
+final class H2FlowControlTest extends TestCase
+{
+    public function testReadRequestBodySendsWindowUpdatesAfterThreshold(): void
+    {
+        $threshold = H2Connection::DEFAULT_WINDOW_UPDATE_THRESHOLD;
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+            /** @var list<H2Frame> */
+            public array $sentFrames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->sentFrames[] = $frame;
+            }
+        };
+        $connection->frames = [
+            new H2Frame(H2Frame::TYPE_DATA, 0, 1, str_repeat('a', $threshold)),
+            new H2Frame(H2Frame::TYPE_DATA, H2Frame::FLAG_END_STREAM, 1, ''),
+        ];
+
+        $body = $connection->readRequestBody(1);
+
+        $this->assertSame(str_repeat('a', $threshold), $body);
+        $this->assertCount(2, $connection->sentFrames);
+        $this->assertSame(H2Frame::TYPE_WINDOW_UPDATE, $connection->sentFrames[0]->type);
+        $this->assertSame(0, $connection->sentFrames[0]->streamId);
+        $this->assertSame(H2Frame::TYPE_WINDOW_UPDATE, $connection->sentFrames[1]->type);
+        $this->assertSame(1, $connection->sentFrames[1]->streamId);
+    }
+
+    public function testReadRequestBodyRejectsWhenConnectionWindowExhausted(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->connectionReceiveWindow = 2;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $connection->frames = [
+            new H2Frame(H2Frame::TYPE_DATA, H2Frame::FLAG_END_STREAM, 1, 'abc'),
+        ];
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Connection receive window exhausted');
+
+        $connection->readRequestBody(1);
+    }
+
+    public function testReadRequestBodyRejectsWhenStreamWindowExhausted(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->streamReceiveWindows[1] = 2;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $connection->frames = [
+            new H2Frame(H2Frame::TYPE_DATA, H2Frame::FLAG_END_STREAM, 1, 'abc'),
+        ];
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Stream receive window exhausted');
+
+        $connection->readRequestBody(1);
+    }
+
+    public function testEmptyDataDoesNotTriggerWindowUpdate(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+            /** @var list<H2Frame> */
+            public array $sentFrames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->sentFrames[] = $frame;
+            }
+        };
+        $connection->frames = [
+            new H2Frame(H2Frame::TYPE_DATA, H2Frame::FLAG_END_STREAM, 1, ''),
+        ];
+
+        $body = $connection->readRequestBody(1);
+
+        $this->assertSame('', $body);
+        $this->assertCount(0, $connection->sentFrames);
+    }
+
+    public function testReadRequestBodyUsesUpdatedInitialWindowSizeForNewStream(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_SETTINGS, 0, 0, pack('nN', 0x4, 4)));
+        $connection->frames = [
+            new H2Frame(H2Frame::TYPE_DATA, H2Frame::FLAG_END_STREAM, 3, 'abcd'),
+        ];
+
+        $body = $connection->readRequestBody(3);
+
+        $this->assertSame('abcd', $body);
+    }
+
+    public function testReadRequestBodyRejectsPayloadExceedingUpdatedInitialWindowSize(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_SETTINGS, 0, 0, pack('nN', 0x4, 2)));
+        $connection->frames = [
+            new H2Frame(H2Frame::TYPE_DATA, H2Frame::FLAG_END_STREAM, 5, 'abc'),
+        ];
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Stream receive window exhausted');
+
+        $connection->readRequestBody(5);
+    }
+
+    public function testWindowUpdateMakesStreamSendWindowReadableForSubsequentLogic(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            public function exposeStreamSendWindow(int $streamId): int
+            {
+                return $this->streamSendWindows[$streamId] ?? self::DEFAULT_INITIAL_WINDOW_SIZE;
+            }
+        };
+
+        $connection->validateFrame(new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 7, pack('N', 512)));
+
+        $this->assertSame(H2Connection::DEFAULT_INITIAL_WINDOW_SIZE + 512, $connection->exposeStreamSendWindow(7));
+    }
+}

--- a/lib/swow-library/tests/Http/Protocol/H2FrameSchedulerTest.php
+++ b/lib/swow-library/tests/Http/Protocol/H2FrameSchedulerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swow\Tests\Http\Protocol;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Swow\Http\Protocol\H2Exception;
+use Swow\Http\Protocol\H2Frame;
+use Swow\Http\Protocol\H2FrameScheduler;
+use Swow\Http\Protocol\H2PendingFrameQueue;
+
+#[CoversClass(H2FrameScheduler::class)]
+final class H2FrameSchedulerTest extends TestCase
+{
+    public function testNextRequestStartFramePumpsControlFramesBeforeDeferredRequestStarts(): void
+    {
+        $scheduler = new H2FrameScheduler(
+            new H2PendingFrameQueue(),
+            static fn(H2Frame $frame): bool => in_array($frame->type, [H2Frame::TYPE_GOAWAY, H2Frame::TYPE_WINDOW_UPDATE], true)
+        );
+
+        $scheduler->defer(new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS, 3, 'h'));
+        $scheduler->defer(new H2Frame(H2Frame::TYPE_GOAWAY, 0, 0, pack('NN', 3, H2Exception::ERROR_NO_ERROR)));
+
+        $pumped = [];
+        $frame = $scheduler->nextRequestStartFrame(
+            static fn() => throw new \RuntimeException('not expected'),
+            static function (H2Frame $frame) use (&$pumped): void {
+                $pumped[] = $frame->type;
+            },
+            static fn(): bool => true,
+            static fn(\Throwable $exception): bool => false,
+        );
+
+        $this->assertSame([H2Frame::TYPE_GOAWAY], $pumped);
+        $this->assertSame(3, $frame?->streamId);
+    }
+
+    public function testNextRelevantFrameForStreamDefersDifferentStreamFramesUntilLater(): void
+    {
+        $scheduler = new H2FrameScheduler(
+            new H2PendingFrameQueue(),
+            static fn(H2Frame $frame): bool => $frame->type === H2Frame::TYPE_WINDOW_UPDATE
+        );
+        $frames = [
+            new H2Frame(H2Frame::TYPE_DATA, H2Frame::FLAG_END_STREAM, 3, 'other'),
+            new H2Frame(H2Frame::TYPE_DATA, H2Frame::FLAG_END_STREAM, 1, 'body'),
+        ];
+
+        $frame = $scheduler->nextRelevantFrameForStream(
+            static function () use (&$frames): H2Frame {
+                $frame = array_shift($frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            },
+            1
+        );
+
+        $this->assertSame(1, $frame->streamId);
+        $this->assertSame('body', $frame->payload);
+        $this->assertSame(3, $scheduler->takePendingFrameForStream(3)?->streamId);
+    }
+}

--- a/lib/swow-library/tests/Http/Protocol/H2FrameTest.php
+++ b/lib/swow-library/tests/Http/Protocol/H2FrameTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * This file is part of Swow
+ *
+ * @link    https://github.com/swow/swow
+ * @contact twosee <twosee@php.net>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code
+ */
+
+declare(strict_types=1);
+
+namespace Swow\Tests\Http\Protocol;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Swow\Http\Protocol\H2Exception;
+use Swow\Http\Protocol\H2Frame;
+
+/**
+ * @internal
+ */
+#[CoversClass(H2Frame::class)]
+#[CoversClass(H2Exception::class)]
+final class H2FrameTest extends TestCase
+{
+    public function testEncodeAndDecodeHeader(): void
+    {
+        $header = H2Frame::encodeHeader(5, H2Frame::TYPE_DATA, H2Frame::FLAG_END_STREAM, 1);
+        $decoded = H2Frame::decodeHeader($header);
+
+        $this->assertSame(5, $decoded['length']);
+        $this->assertSame(H2Frame::TYPE_DATA, $decoded['type']);
+        $this->assertSame(H2Frame::FLAG_END_STREAM, $decoded['flags']);
+        $this->assertSame(1, $decoded['streamId']);
+    }
+
+    public function testFromHeaderAndPayloadCreatesFrame(): void
+    {
+        $payload = 'hello';
+        $header = H2Frame::encodeHeader(strlen($payload), H2Frame::TYPE_DATA, 0, 3);
+        $frame = H2Frame::fromHeaderAndPayload($header, $payload);
+
+        $this->assertSame(H2Frame::TYPE_DATA, $frame->type);
+        $this->assertSame(0, $frame->flags);
+        $this->assertSame(3, $frame->streamId);
+        $this->assertSame($payload, $frame->payload);
+        $this->assertSame($header . $payload, $frame->encode());
+    }
+
+    public function testDecodeHeaderRejectsInvalidHeaderLength(): void
+    {
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Invalid frame header length');
+
+        H2Frame::decodeHeader('short');
+    }
+
+    public function testFromHeaderAndPayloadRejectsMismatchedPayloadLength(): void
+    {
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Frame payload length mismatch');
+
+        $header = H2Frame::encodeHeader(4, H2Frame::TYPE_DATA, 0, 1);
+        H2Frame::fromHeaderAndPayload($header, 'abc');
+    }
+}

--- a/lib/swow-library/tests/Http/Protocol/H2HeaderBlockTest.php
+++ b/lib/swow-library/tests/Http/Protocol/H2HeaderBlockTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * This file is part of Swow
+ *
+ * @link    https://github.com/swow/swow
+ * @contact twosee <twosee@php.net>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code
+ */
+
+declare(strict_types=1);
+
+namespace Swow\Tests\Http\Protocol;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Swow\Http\Protocol\H2Connection;
+use Swow\Http\Protocol\H2Exception;
+use Swow\Http\Protocol\H2Frame;
+use Swow\Http\Protocol\H2HeaderBlock;
+use Swow\Socket;
+
+/**
+ * @internal
+ */
+#[CoversClass(H2HeaderBlock::class)]
+#[CoversClass(H2Connection::class)]
+final class H2HeaderBlockTest extends TestCase
+{
+    public function testHeaderBlockAppendSingleHeadersFrame(): void
+    {
+        $block = new H2HeaderBlock(1);
+        $block->append(new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS, 1, 'abc'));
+
+        $this->assertTrue($block->isCompleted());
+        $this->assertSame('abc', $block->getBuffer());
+    }
+
+    public function testHeaderBlockAppendHeadersAndContinuation(): void
+    {
+        $block = new H2HeaderBlock(1);
+        $block->append(new H2Frame(H2Frame::TYPE_HEADERS, 0, 1, 'abc'));
+        $block->append(new H2Frame(H2Frame::TYPE_CONTINUATION, H2Frame::FLAG_END_HEADERS, 1, 'def'));
+
+        $this->assertTrue($block->isCompleted());
+        $this->assertSame('abcdef', $block->getBuffer());
+    }
+
+    public function testHeaderBlockRejectsInterruptingFrame(): void
+    {
+        $block = new H2HeaderBlock(1);
+        $block->append(new H2Frame(H2Frame::TYPE_HEADERS, 0, 1, 'abc'));
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Header block was interrupted by a non-continuation frame');
+
+        $block->append(new H2Frame(H2Frame::TYPE_DATA, 0, 1, 'x'));
+    }
+
+    public function testHeaderBlockRejectsDifferentStreamContinuation(): void
+    {
+        $block = new H2HeaderBlock(1);
+        $block->append(new H2Frame(H2Frame::TYPE_HEADERS, 0, 1, 'abc'));
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('CONTINUATION frame stream does not match active header block');
+
+        $block->append(new H2Frame(H2Frame::TYPE_CONTINUATION, H2Frame::FLAG_END_HEADERS, 3, 'def'));
+    }
+
+    public function testReadHeaderBlockCollectsUntilEndHeaders(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $connection->frames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, 0, 1, 'abc'),
+            new H2Frame(H2Frame::TYPE_CONTINUATION, H2Frame::FLAG_END_HEADERS, 1, 'def'),
+        ];
+
+        $block = $connection->readHeaderBlock();
+
+        $this->assertSame(1, $block->getStreamId());
+        $this->assertSame('abcdef', $block->getBuffer());
+        $this->assertTrue($block->isCompleted());
+    }
+}

--- a/lib/swow-library/tests/Http/Protocol/H2HpackTest.php
+++ b/lib/swow-library/tests/Http/Protocol/H2HpackTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * This file is part of Swow
+ *
+ * @link    https://github.com/swow/swow
+ * @contact twosee <twosee@php.net>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code
+ */
+
+declare(strict_types=1);
+
+namespace Swow\Tests\Http\Protocol;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Swow\Http\Protocol\H2Exception;
+use Swow\Http\Protocol\H2Hpack;
+use Swow\Psr7\Server\H2ServerConnection;
+
+/**
+ * @internal
+ */
+#[CoversClass(H2Hpack::class)]
+#[CoversClass(H2ServerConnection::class)]
+final class H2HpackTest extends TestCase
+{
+    public function testDecodeRfcC4RequestWithHuffman(): void
+    {
+        $decoder = new H2Hpack();
+        $headers = $decoder->decode(hex2bin('828684418cf1e3c2e5f23a6ba0ab90f4ff'));
+
+        $this->assertCount(4, $headers);
+        $this->assertSame(':method', $headers[0]['name']);
+        $this->assertSame('GET', $headers[0]['value']);
+        $this->assertSame(':scheme', $headers[1]['name']);
+        $this->assertSame('http', $headers[1]['value']);
+        $this->assertSame(':path', $headers[2]['name']);
+        $this->assertSame('/', $headers[2]['value']);
+        $this->assertSame(':authority', $headers[3]['name']);
+        $this->assertSame('www.example.com', $headers[3]['value']);
+    }
+
+    public function testDecodeIndexedHeaders(): void
+    {
+        $decoder = new H2Hpack();
+        $headers = $decoder->decode("\x82\x87\x84");
+
+        $this->assertSame(':method', $headers[0]['name']);
+        $this->assertSame('GET', $headers[0]['value']);
+        $this->assertSame(':scheme', $headers[1]['name']);
+        $this->assertSame('https', $headers[1]['value']);
+        $this->assertSame(':path', $headers[2]['name']);
+        $this->assertSame('/', $headers[2]['value']);
+    }
+
+    public function testDecodeLiteralHeaders(): void
+    {
+        $decoder = new H2Hpack();
+        $headers = $decoder->decode(
+            "\x82" .               // :method GET
+            "\x41\x0bexample.com" . // literal with indexed name :authority
+            "\x40\x04host\x0bexample.com" // literal with incremental indexing
+        );
+
+        $this->assertSame(':method', $headers[0]['name']);
+        $this->assertSame('GET', $headers[0]['value']);
+        $this->assertSame(':authority', $headers[1]['name']);
+        $this->assertSame('example.com', $headers[1]['value']);
+        $this->assertSame('host', $headers[2]['name']);
+        $this->assertSame('example.com', $headers[2]['value']);
+    }
+
+    public function testDecodeSupportsDynamicTableAcrossBlocks(): void
+    {
+        $decoder = new H2Hpack();
+        $decoder->decode(hex2bin('400a637573746f6d2d6b65790d637573746f6d2d686561646572'));
+        $headers = $decoder->decode(hex2bin('be'));
+
+        $this->assertCount(1, $headers);
+        $this->assertSame('custom-key', $headers[0]['name']);
+        $this->assertSame('custom-header', $headers[0]['value']);
+    }
+
+    public function testDecodeEvictsDynamicEntriesAfterTableShrink(): void
+    {
+        $decoder = new H2Hpack(64);
+        $decoder->decode(hex2bin('3f01'));
+        $decoder->decode(hex2bin('40036162630464656667'));
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('HPACK index out of range');
+
+        $decoder->decode(hex2bin('be'));
+    }
+
+    public function testRecvRequestFromHeaderBlockSupportsDynamicTableAcrossCalls(): void
+    {
+        $connection = new H2ServerConnection();
+        $connection->recvRequestFromHeaderBlock(
+            hex2bin('828784010b6578616d706c652e636f6d400a637573746f6d2d6b65790c637573746f6d2d76616c7565')
+        );
+        $request = $connection->recvRequestFromHeaderBlock(
+            hex2bin('828784010b6578616d706c652e636f6dbe')
+        );
+
+        $this->assertSame('custom-value', $request->getHeaderLine('custom-key'));
+    }
+
+    public function testDecodeRejectsInvalidIndex(): void
+    {
+        $decoder = new H2Hpack();
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('HPACK index must be positive');
+
+        $decoder->decode("\x80");
+    }
+
+    public function testDecodeRejectsTableSizeUpdateBeyondLimit(): void
+    {
+        $decoder = new H2Hpack(128);
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('HPACK table size update exceeds allowed maximum');
+
+        $decoder->decode("\x3f\xe1\x01");
+    }
+
+    public function testRecvRequestFromHeaderBlockCreatesServerRequest(): void
+    {
+        $connection = new H2ServerConnection();
+        $request = $connection->recvRequestFromHeaderBlock(
+            "\x82" .                 // :method GET
+            "\x87" .                 // :scheme https
+            "\x41\x0bexample.com" .  // :authority: example.com
+            "\x44\x06/hello"         // :path: /hello
+        );
+
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('https://example.com/hello', (string) $request->getUri());
+        $this->assertSame('example.com', $request->getHeaderLine('host'));
+    }
+}

--- a/lib/swow-library/tests/Http/Protocol/H2PendingFrameQueueTest.php
+++ b/lib/swow-library/tests/Http/Protocol/H2PendingFrameQueueTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swow\Tests\Http\Protocol;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Swow\Http\Protocol\H2Frame;
+use Swow\Http\Protocol\H2PendingFrameQueue;
+
+#[CoversClass(H2PendingFrameQueue::class)]
+final class H2PendingFrameQueueTest extends TestCase
+{
+    public function testTakeControlFramePrioritizesControlFrames(): void
+    {
+        $queue = new H2PendingFrameQueue();
+        $request = new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS, 3, 'h');
+        $control = new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 0, pack('N', 1));
+
+        $queue->defer($request);
+        $queue->defer($control);
+
+        $this->assertSame($control, $queue->takeControlFrame(static fn(H2Frame $frame): bool => true));
+        $this->assertSame($request, $queue->takeRequestStartFrame());
+    }
+
+    public function testTakeFrameForStreamReturnsControlFramesBeforeStreamFrames(): void
+    {
+        $queue = new H2PendingFrameQueue();
+        $streamFrame = new H2Frame(H2Frame::TYPE_DATA, 0, 5, 'abc');
+        $control = new H2Frame(H2Frame::TYPE_PING, 0, 0, '12345678');
+
+        $queue->defer($streamFrame);
+        $queue->defer($control);
+
+        $this->assertSame($control, $queue->takeFrameForStream(5, static fn(H2Frame $frame): bool => true));
+        $this->assertSame($streamFrame, $queue->takeFrameForStream(5, static fn(H2Frame $frame): bool => true));
+    }
+
+    public function testShiftReturnsControlThenRequestStartThenStreamFrames(): void
+    {
+        $queue = new H2PendingFrameQueue();
+        $request = new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS, 3, 'h');
+        $streamFrame = new H2Frame(H2Frame::TYPE_DATA, 0, 3, 'abc');
+        $control = new H2Frame(H2Frame::TYPE_GOAWAY, 0, 0, pack('NN', 1, 0));
+
+        $queue->defer($streamFrame);
+        $queue->defer($request);
+        $queue->defer($control);
+
+        $this->assertSame($control, $queue->shift());
+        $this->assertSame($request, $queue->shift());
+        $this->assertSame($streamFrame, $queue->shift());
+        $this->assertNull($queue->shift());
+    }
+
+    public function testShiftRoundsRobinAcrossDeferredStreamFrames(): void
+    {
+        $queue = new H2PendingFrameQueue();
+        $streamThreeA = new H2Frame(H2Frame::TYPE_DATA, 0, 3, 'a');
+        $streamThreeB = new H2Frame(H2Frame::TYPE_DATA, 0, 3, 'b');
+        $streamFive = new H2Frame(H2Frame::TYPE_DATA, 0, 5, 'c');
+
+        $queue->defer($streamThreeA);
+        $queue->defer($streamThreeB);
+        $queue->defer($streamFive);
+
+        $this->assertSame($streamThreeA, $queue->shift());
+        $this->assertSame($streamFive, $queue->shift());
+        $this->assertSame($streamThreeB, $queue->shift());
+        $this->assertNull($queue->shift());
+    }
+}

--- a/lib/swow-library/tests/Http/Protocol/H2RequestBodyProtocolTest.php
+++ b/lib/swow-library/tests/Http/Protocol/H2RequestBodyProtocolTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * This file is part of Swow
+ *
+ * @link    https://github.com/swow/swow
+ * @contact twosee <twosee@php.net>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code
+ */
+
+declare(strict_types=1);
+
+namespace Swow\Tests\Http\Protocol;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Swow\Http\Protocol\H2Connection;
+use Swow\Http\Protocol\H2Exception;
+use Swow\Http\Protocol\H2Frame;
+use Swow\Socket;
+
+/**
+ * @internal
+ */
+#[CoversClass(H2Connection::class)]
+final class H2RequestBodyProtocolTest extends TestCase
+{
+    public function testReadRequestBodyAllowsEmptyDataFrameWithEndStream(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $connection->frames = [
+            new H2Frame(H2Frame::TYPE_DATA, H2Frame::FLAG_END_STREAM, 1, ''),
+        ];
+
+        $this->assertSame('', $connection->readRequestBody(1));
+    }
+
+    public function testReadRequestBodyDefersDifferentStreamFrames(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $connection->frames = [
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM,
+                3,
+                "\x82\x87\x41\x0bexample.com\x45\x04/next"
+            ),
+            new H2Frame(H2Frame::TYPE_DATA, H2Frame::FLAG_END_STREAM, 1, 'body'),
+        ];
+
+        $this->assertSame('body', $connection->readRequestBody(1));
+        $nextRequest = $connection->readHeaderBlock();
+        $this->assertSame(3, $nextRequest->getStreamId());
+    }
+
+    public function testReadRequestBodyWithTrailersReturnsTrailerBlock(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $connection->frames = [
+            new H2Frame(H2Frame::TYPE_DATA, 0, 1, 'body'),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, 'trailers'),
+        ];
+
+        $result = $connection->readRequestBodyWithTrailers(1);
+
+        $this->assertSame('body', $result['body']);
+        $this->assertNotNull($result['trailers']);
+        $this->assertSame('trailers', $result['trailers']?->getBuffer());
+    }
+
+    public function testReadRequestBodyRejectsNonDataFrame(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $connection->frames = [
+            new H2Frame(H2Frame::TYPE_CONTINUATION, 0, 1, 'bad'),
+        ];
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Expected DATA or trailing HEADERS frame while reading request body');
+
+        $connection->readRequestBody(1);
+    }
+
+    public function testReadRequestBodyRejectsTrailingHeadersWithoutEndStream(): void
+    {
+        $connection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $connection->frames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS, 1, 'trailers'),
+        ];
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Trailing HEADERS frame must end the request stream');
+
+        $connection->readRequestBodyWithTrailers(1);
+    }
+}

--- a/lib/swow-library/tests/Http/Protocol/H2StreamStateMatrixTest.php
+++ b/lib/swow-library/tests/Http/Protocol/H2StreamStateMatrixTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swow\Tests\Http\Protocol;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Swow\Http\Protocol\H2Connection;
+use Swow\Http\Protocol\H2Exception;
+use Swow\Http\Protocol\H2Frame;
+use Swow\Http\Protocol\H2StreamStateMatrix;
+
+#[CoversClass(H2StreamStateMatrix::class)]
+final class H2StreamStateMatrixTest extends TestCase
+{
+    public function testAssertCanSendRejectsHalfClosedLocal(): void
+    {
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Cannot send on locally closed stream');
+
+        H2StreamStateMatrix::assertCanSend(1, H2Connection::STREAM_STATE_HALF_CLOSED_LOCAL);
+    }
+
+    public function testAssertCanReceiveDataRejectsHalfClosedRemote(): void
+    {
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Cannot receive DATA on remotely closed stream');
+
+        H2StreamStateMatrix::assertCanReceiveData(1, H2Connection::STREAM_STATE_HALF_CLOSED_REMOTE);
+    }
+
+    public function testStateTransitionsCloseStreamWhenBothSidesEnded(): void
+    {
+        $this->assertSame(
+            H2Connection::STREAM_STATE_CLOSED,
+            H2StreamStateMatrix::stateAfterRemoteEnded(H2Connection::STREAM_STATE_HALF_CLOSED_LOCAL)
+        );
+        $this->assertSame(
+            H2Connection::STREAM_STATE_CLOSED,
+            H2StreamStateMatrix::stateAfterLocalEnded(H2Connection::STREAM_STATE_HALF_CLOSED_REMOTE)
+        );
+    }
+
+    public function testValidateInboundFrameRejectsClosedDataFrame(): void
+    {
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Frame received for closed stream');
+
+        H2StreamStateMatrix::validateInboundFrame(
+            new H2Frame(H2Frame::TYPE_DATA, 0, 1, 'a'),
+            H2Connection::STREAM_STATE_CLOSED,
+            true,
+            false,
+            false
+        );
+    }
+}

--- a/lib/swow-library/tests/Psr7/Server/EventDriverTest.php
+++ b/lib/swow-library/tests/Psr7/Server/EventDriverTest.php
@@ -1,0 +1,873 @@
+<?php
+
+/**
+ * This file is part of Swow
+ *
+ * @link    https://github.com/swow/swow
+ * @contact twosee <twosee@php.net>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code
+ */
+
+declare(strict_types=1);
+
+namespace Swow\Tests\Psr7\Server;
+
+use Closure;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
+use Swow\Http\Protocol\H2Connection;
+use Swow\Http\Protocol\H2Exception;
+use Swow\Http\Protocol\H2Frame;
+use Swow\Psr7\Psr7;
+use Swow\Psr7\Server\EventDriver;
+use Swow\Psr7\Server\EventDriverConnectionHandler;
+use Swow\Psr7\Server\H2ResponseEnvelope;
+use Swow\Psr7\Server\H2ServerConnection;
+use Swow\Psr7\Server\Server;
+use Swow\Psr7\Server\ServerConnection;
+use Swow\Socket;
+
+/**
+ * @internal
+ */
+#[CoversClass(EventDriver::class)]
+#[CoversClass(EventDriverConnectionHandler::class)]
+final class EventDriverTest extends TestCase
+{
+    public function testEventDriverHandlesH2Connection(): void
+    {
+        $protocol = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+            public int $prefaceReads = 0;
+            public bool $initialized = false;
+
+            public function readClientPreface(?int $timeout = null): void
+            {
+                $this->prefaceReads++;
+            }
+
+            public function initialize(?int $timeout = null, array $settings = []): void
+            {
+                $this->initialized = true;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+        $protocol->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ];
+        $connection = new H2ServerConnection(connection: $protocol);
+        $driver = $this->createEventDriverRunner(
+            static function ($connection, ServerRequestInterface $request): array {
+                return [201, ['x-event-driver' => 'h2'], 'done'];
+            }
+        );
+
+        $driver->runAcceptedConnection($connection);
+
+        $this->assertSame(1, $protocol->prefaceReads);
+        $this->assertTrue($protocol->initialized);
+        $this->assertCount(2, $protocol->writtenFrames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $protocol->writtenFrames[0]->type);
+        $this->assertSame(H2Frame::TYPE_DATA, $protocol->writtenFrames[1]->type);
+    }
+
+    public function testEventDriverNaturallyStopsOnH2Eof(): void
+    {
+        $protocol = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            public int $prefaceReads = 0;
+            public bool $initialized = false;
+
+            public function readClientPreface(?int $timeout = null): void
+            {
+                $this->prefaceReads++;
+            }
+
+            public function initialize(?int $timeout = null, array $settings = []): void
+            {
+                $this->initialized = true;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                throw new RuntimeException('No frame queued');
+            }
+        };
+        $connection = new H2ServerConnection(connection: $protocol);
+        $driver = $this->createEventDriverRunner(
+            static fn($connection, ServerRequestInterface $request): ResponseInterface => Psr7::createResponse(204)
+        );
+
+        $driver->runAcceptedConnection($connection);
+
+        $this->assertSame(1, $protocol->prefaceReads);
+        $this->assertTrue($protocol->initialized);
+    }
+
+    public function testEventDriverStillHandlesHttpConnection(): void
+    {
+        $request = Psr7::createServerRequest('GET', '/event-driver', []);
+        $connection = new class(new Server(), $request) extends ServerConnection {
+            public ?ResponseInterface $sentResponse = null;
+            public bool $closed = false;
+            public function __construct(Server $server, private ServerRequestInterface $request)
+            {
+                parent::__construct($server);
+            }
+
+            public function recvHttpRequest(?int $timeout = null): ServerRequestInterface
+            {
+                return $this->request;
+            }
+
+            public function sendHttpResponse(ResponseInterface $response): static
+            {
+                $this->sentResponse = $response;
+                return $this;
+            }
+
+            public function shouldKeepAlive(): bool
+            {
+                return false;
+            }
+
+            public function close(): bool
+            {
+                $this->closed = true;
+                return true;
+            }
+        };
+        $driver = $this->createEventDriverRunner(
+            static fn($connection, ServerRequestInterface $request): ResponseInterface => Psr7::createResponse(202)
+        );
+
+        $driver->runAcceptedConnection($connection);
+
+        $this->assertInstanceOf(ResponseInterface::class, $connection->sentResponse);
+        $this->assertSame(202, $connection->sentResponse->getStatusCode());
+        $this->assertTrue($connection->closed);
+    }
+
+    public function testEventDriverInvokesExceptionAndCloseHandlersForH2ConnectionError(): void
+    {
+        $protocol = $this->createH2ProtocolWithFrames([
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ]);
+        $connection = new H2ServerConnection(connection: $protocol);
+        $caughtException = null;
+        $closedConnection = null;
+        $driver = $this->createEventDriverRunner(
+            static function ($connection, ServerRequestInterface $request) {
+                throw H2Exception::forConnectionError('boom');
+            }
+        )
+            ->withExceptionHandler(function ($connection, \Throwable $exception) use (&$caughtException): void {
+                $caughtException = $exception;
+            })
+            ->withCloseHandler(function ($connection) use (&$closedConnection): void {
+                $closedConnection = $connection;
+            });
+
+        $driver->runAcceptedConnection($connection);
+
+        $this->assertInstanceOf(H2Exception::class, $caughtException);
+        $this->assertSame('boom', $caughtException->getMessage());
+        $this->assertSame($connection, $closedConnection);
+    }
+
+    public function testEventDriverInvokesExceptionAndCloseHandlersForH2TypeError(): void
+    {
+        $protocol = $this->createH2ProtocolWithFrames([
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ]);
+        $connection = new H2ServerConnection(connection: $protocol);
+        $caughtException = null;
+        $closeCount = 0;
+        $driver = $this->createEventDriverRunner(
+            static fn($connection, ServerRequestInterface $request): object => new \stdClass()
+        )
+            ->withExceptionHandler(function ($connection, \Throwable $exception) use (&$caughtException): void {
+                $caughtException = $exception;
+            })
+            ->withCloseHandler(function () use (&$closeCount): void {
+                $closeCount++;
+            });
+
+        $driver->runAcceptedConnection($connection);
+
+        $this->assertInstanceOf(\TypeError::class, $caughtException);
+        $this->assertSame(1, $closeCount);
+    }
+
+    public function testEventDriverInvokesExceptionHandlerForH2NullResponse(): void
+    {
+        $protocol = $this->createH2ProtocolWithFrames([
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ]);
+        $connection = new H2ServerConnection(connection: $protocol);
+        $caughtException = null;
+        $driver = $this->createEventDriverRunner(
+            static fn($connection, ServerRequestInterface $request) => null
+        )->withExceptionHandler(function ($connection, \Throwable $exception) use (&$caughtException): void {
+            $caughtException = $exception;
+        });
+
+        $driver->runAcceptedConnection($connection);
+
+        $this->assertInstanceOf(\TypeError::class, $caughtException);
+    }
+
+    public function testEventDriverH2AcceptsStatusOnlyResponse(): void
+    {
+        $protocol = $this->createH2ProtocolWithFrames([
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ]);
+        $connection = new H2ServerConnection(connection: $protocol);
+        $driver = $this->createEventDriverRunner(
+            static fn($connection, ServerRequestInterface $request): int => 204
+        );
+
+        $driver->runAcceptedConnection($connection);
+
+        $this->assertCount(1, $protocol->writtenFrames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $protocol->writtenFrames[0]->type);
+        $this->assertSame(H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, $protocol->writtenFrames[0]->flags);
+    }
+
+    public function testEventDriverH2AcceptsStringResponse(): void
+    {
+        $protocol = $this->createH2ProtocolWithFrames([
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ]);
+        $connection = new H2ServerConnection(connection: $protocol);
+        $driver = $this->createEventDriverRunner(
+            static fn($connection, ServerRequestInterface $request): string => 'plain-body'
+        );
+
+        $driver->runAcceptedConnection($connection);
+
+        $this->assertCount(2, $protocol->writtenFrames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $protocol->writtenFrames[0]->type);
+        $this->assertSame(H2Frame::TYPE_DATA, $protocol->writtenFrames[1]->type);
+        $this->assertSame('plain-body', $protocol->writtenFrames[1]->payload);
+    }
+
+    public function testEventDriverH2AcceptsArrayResponse(): void
+    {
+        $protocol = $this->createH2ProtocolWithFrames([
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ]);
+        $connection = new H2ServerConnection(connection: $protocol);
+        $driver = $this->createEventDriverRunner(
+            static fn($connection, ServerRequestInterface $request): array => [203, ['x-array' => 'yes'], 'array-body']
+        );
+
+        $driver->runAcceptedConnection($connection);
+
+        $this->assertCount(2, $protocol->writtenFrames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $protocol->writtenFrames[0]->type);
+        $this->assertSame(H2Frame::TYPE_DATA, $protocol->writtenFrames[1]->type);
+        $this->assertSame('array-body', $protocol->writtenFrames[1]->payload);
+    }
+
+    public function testEventDriverH2AcceptsResponseEnvelopeWithTrailers(): void
+    {
+        $protocol = $this->createH2ProtocolWithFrames([
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ]);
+        $connection = new H2ServerConnection(connection: $protocol);
+        $driver = $this->createEventDriverRunner(
+            static fn($connection, ServerRequestInterface $request) => H2ResponseEnvelope::from(
+                Psr7::createResponse(200, body: 'array-body'),
+                ['x-trailer' => 'done']
+            )
+        );
+
+        $driver->runAcceptedConnection($connection);
+
+        $this->assertCount(3, $protocol->writtenFrames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $protocol->writtenFrames[0]->type);
+        $this->assertSame(H2Frame::TYPE_DATA, $protocol->writtenFrames[1]->type);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $protocol->writtenFrames[2]->type);
+        $this->assertSame(H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, $protocol->writtenFrames[2]->flags);
+    }
+
+    public function testEventDriverH2AcceptsArrayResponseWithTrailers(): void
+    {
+        $protocol = $this->createH2ProtocolWithFrames([
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ]);
+        $connection = new H2ServerConnection(connection: $protocol);
+        $driver = $this->createEventDriverRunner(
+            static fn($connection, ServerRequestInterface $request): array => [202, ['x-array' => 'yes'], 'array-body', ['x-trailer' => 'done']]
+        );
+
+        $driver->runAcceptedConnection($connection);
+
+        $this->assertCount(3, $protocol->writtenFrames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $protocol->writtenFrames[0]->type);
+        $this->assertSame(H2Frame::TYPE_DATA, $protocol->writtenFrames[1]->type);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $protocol->writtenFrames[2]->type);
+    }
+
+    public function testEventDriverH2AcceptsNamedResponseMapWithTrailers(): void
+    {
+        $protocol = $this->createH2ProtocolWithFrames([
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ]);
+        $connection = new H2ServerConnection(connection: $protocol);
+        $driver = $this->createEventDriverRunner(
+            static fn($connection, ServerRequestInterface $request): array => [
+                'status' => 202,
+                'headers' => ['x-named' => 'yes'],
+                'body' => 'array-body',
+                'trailers' => ['x-trailer' => 'done'],
+            ]
+        );
+
+        $driver->runAcceptedConnection($connection);
+
+        $this->assertCount(3, $protocol->writtenFrames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $protocol->writtenFrames[0]->type);
+        $this->assertSame(H2Frame::TYPE_DATA, $protocol->writtenFrames[1]->type);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $protocol->writtenFrames[2]->type);
+    }
+
+    public function testEventDriverAutoPromotesDirectH2Preface(): void
+    {
+        $protocol = $this->createH2ProtocolWithFrames([
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ]);
+        $httpConnection = new class(new Server()) extends ServerConnection {
+            public bool $closed = false;
+
+            public function peekString(int $size = 8192, ?int $timeout = 0): string
+            {
+                return H2Connection::CLIENT_PREFACE;
+            }
+
+            public function close(): bool
+            {
+                $this->closed = true;
+                return true;
+            }
+        };
+        $driver = $this->createEventDriverRunnerWithOverrides(
+            static fn($connection, ServerRequestInterface $request): string => 'promoted',
+            static function (?Closure $connectionHandler, ?Closure $requestHandler, ?Closure $upgradeHandler, ?Closure $messageHandler, ?Closure $closeHandler, ?Closure $exceptionHandler) use ($protocol): EventDriverConnectionHandler {
+                return new class($connectionHandler, $requestHandler, $upgradeHandler, $messageHandler, $closeHandler, $exceptionHandler, $protocol) extends EventDriverConnectionHandler {
+                    public function __construct(
+                        ?Closure $connectionHandler,
+                        ?Closure $requestHandler,
+                        ?Closure $upgradeHandler,
+                        ?Closure $messageHandler,
+                        ?Closure $closeHandler,
+                        ?Closure $exceptionHandler,
+                        private H2Connection $protocol,
+                    ) {
+                        parent::__construct($connectionHandler, $requestHandler, $upgradeHandler, $messageHandler, $closeHandler, $exceptionHandler);
+                    }
+
+                    protected function createH2ServerConnectionFromSocket(Socket $socket, array $serverParams = []): H2ServerConnection
+                    {
+                        return new H2ServerConnection(connection: $this->protocol);
+                    }
+                };
+            }
+        );
+
+        $driver->runAcceptedConnection($httpConnection);
+
+        $this->assertSame(1, $protocol->prefaceReads);
+        $this->assertTrue($protocol->initialized);
+        $this->assertCount(2, $protocol->writtenFrames);
+    }
+
+    public function testEventDriverAutoPromotesNegotiatedH2AlpnWithoutPrefacePeek(): void
+    {
+        $protocol = $this->createH2ProtocolWithFrames([
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ]);
+        $httpConnection = new class(new Server()) extends ServerConnection {
+            public bool $peeked = false;
+
+            public function getNegotiatedAlpnProtocol(): ?string
+            {
+                return 'h2';
+            }
+
+            public function peekString(int $size = 8192, ?int $timeout = 0): string
+            {
+                $this->peeked = true;
+                return 'GET / HTTP/1.1';
+            }
+        };
+        $driver = $this->createEventDriverRunnerWithOverrides(
+            static fn($connection, ServerRequestInterface $request): string => 'alpn-h2',
+            static function (?Closure $connectionHandler, ?Closure $requestHandler, ?Closure $upgradeHandler, ?Closure $messageHandler, ?Closure $closeHandler, ?Closure $exceptionHandler) use ($protocol): EventDriverConnectionHandler {
+                return new class($connectionHandler, $requestHandler, $upgradeHandler, $messageHandler, $closeHandler, $exceptionHandler, $protocol) extends EventDriverConnectionHandler {
+                    public function __construct(
+                        ?Closure $connectionHandler,
+                        ?Closure $requestHandler,
+                        ?Closure $upgradeHandler,
+                        ?Closure $messageHandler,
+                        ?Closure $closeHandler,
+                        ?Closure $exceptionHandler,
+                        private H2Connection $protocol,
+                    ) {
+                        parent::__construct($connectionHandler, $requestHandler, $upgradeHandler, $messageHandler, $closeHandler, $exceptionHandler);
+                    }
+
+                    protected function createH2ServerConnectionFromSocket(Socket $socket, array $serverParams = []): H2ServerConnection
+                    {
+                        return new H2ServerConnection(connection: $this->protocol);
+                    }
+                };
+            }
+        );
+
+        $driver->runAcceptedConnection($httpConnection);
+
+        $this->assertFalse($httpConnection->peeked);
+        $this->assertSame(1, $protocol->prefaceReads);
+        $this->assertTrue($protocol->initialized);
+        $this->assertCount(2, $protocol->writtenFrames);
+    }
+
+    public function testEventDriverKeepsHttpWhenNegotiatedAlpnIsHttp11(): void
+    {
+        $request = Psr7::createServerRequest('GET', '/event-driver', []);
+        $connection = new class(new Server(), $request) extends ServerConnection {
+            public ?ResponseInterface $sentResponse = null;
+            public bool $peeked = false;
+
+            public function __construct(Server $server, private ServerRequestInterface $request)
+            {
+                parent::__construct($server);
+            }
+
+            public function getNegotiatedAlpnProtocol(): ?string
+            {
+                return 'http/1.1';
+            }
+
+            public function peekString(int $size = 8192, ?int $timeout = 0): string
+            {
+                $this->peeked = true;
+                return H2Connection::CLIENT_PREFACE;
+            }
+
+            public function recvHttpRequest(?int $timeout = null): ServerRequestInterface
+            {
+                return $this->request;
+            }
+
+            public function sendHttpResponse(ResponseInterface $response): static
+            {
+                $this->sentResponse = $response;
+                return $this;
+            }
+
+            public function shouldKeepAlive(): bool
+            {
+                return false;
+            }
+        };
+        $driver = $this->createEventDriverRunner(
+            static fn($connection, ServerRequestInterface $request): ResponseInterface => Psr7::createResponse(202)
+        );
+
+        $driver->runAcceptedConnection($connection);
+
+        $this->assertFalse($connection->peeked);
+        $this->assertInstanceOf(ResponseInterface::class, $connection->sentResponse);
+        $this->assertSame(202, $connection->sentResponse->getStatusCode());
+    }
+
+    public function testEventDriverAutoPromotesPartialDirectH2Preface(): void
+    {
+        $protocol = $this->createH2ProtocolWithFrames([
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ]);
+        $httpConnection = new class(new Server()) extends ServerConnection {
+            public bool $closed = false;
+
+            public function peekString(int $size = 8192, ?int $timeout = 0): string
+            {
+                return substr(H2Connection::CLIENT_PREFACE, 0, 8);
+            }
+
+            public function close(): bool
+            {
+                $this->closed = true;
+                return true;
+            }
+        };
+        $driver = $this->createEventDriverRunnerWithOverrides(
+            static fn($connection, ServerRequestInterface $request): string => 'promoted-partial',
+            static function (?Closure $connectionHandler, ?Closure $requestHandler, ?Closure $upgradeHandler, ?Closure $messageHandler, ?Closure $closeHandler, ?Closure $exceptionHandler) use ($protocol): EventDriverConnectionHandler {
+                return new class($connectionHandler, $requestHandler, $upgradeHandler, $messageHandler, $closeHandler, $exceptionHandler, $protocol) extends EventDriverConnectionHandler {
+                    public function __construct(
+                        ?Closure $connectionHandler,
+                        ?Closure $requestHandler,
+                        ?Closure $upgradeHandler,
+                        ?Closure $messageHandler,
+                        ?Closure $closeHandler,
+                        ?Closure $exceptionHandler,
+                        private H2Connection $protocol,
+                    ) {
+                        parent::__construct($connectionHandler, $requestHandler, $upgradeHandler, $messageHandler, $closeHandler, $exceptionHandler);
+                    }
+
+                    protected function createH2ServerConnectionFromSocket(Socket $socket, array $serverParams = []): H2ServerConnection
+                    {
+                        return new H2ServerConnection(connection: $this->protocol);
+                    }
+                };
+            }
+        );
+
+        $driver->runAcceptedConnection($httpConnection);
+
+        $this->assertSame(1, $protocol->prefaceReads);
+        $this->assertTrue($protocol->initialized);
+        $this->assertCount(2, $protocol->writtenFrames);
+    }
+
+    public function testEventDriverHandlesH2cUpgrade(): void
+    {
+        $protocol = $this->createH2ProtocolWithFrames([]);
+        $request = Psr7::createServerRequest(
+            'GET',
+            '/h2c',
+            [],
+            [
+                'Connection' => 'Upgrade, HTTP2-Settings',
+                'Upgrade' => 'h2c',
+                'HTTP2-Settings' => 'AAMAAABk',
+            ]
+        );
+        $request->setIsUpgrade(true);
+        $httpConnection = new class(new Server(), $request) extends ServerConnection {
+            public bool $closed = false;
+            public ?array $switchHeaders = null;
+
+            public function __construct(Server $server, private ServerRequestInterface $request)
+            {
+                parent::__construct($server);
+            }
+
+            public function peekString(int $size = 8192, ?int $timeout = 0): string
+            {
+                return 'GET /h2c HTTP/1.1';
+            }
+
+            public function recvHttpRequest(?int $timeout = null): ServerRequestInterface
+            {
+                return $this->request;
+            }
+
+            public function sendHttpHeader(int $statusCode = 200, string $reasonPhrase = '', array $headers = [], string $protocolVersion = '1.1'): static
+            {
+                $this->switchHeaders = ['status' => $statusCode, 'headers' => $headers];
+                return $this;
+            }
+
+            public function close(): bool
+            {
+                $this->closed = true;
+                return true;
+            }
+        };
+        $driver = $this->createEventDriverRunnerWithOverrides(
+            static fn($connection, ServerRequestInterface $request): string => 'upgraded',
+            static function (?Closure $connectionHandler, ?Closure $requestHandler, ?Closure $upgradeHandler, ?Closure $messageHandler, ?Closure $closeHandler, ?Closure $exceptionHandler) use ($protocol): EventDriverConnectionHandler {
+                return new class($connectionHandler, $requestHandler, $upgradeHandler, $messageHandler, $closeHandler, $exceptionHandler, $protocol) extends EventDriverConnectionHandler {
+                    public function __construct(
+                        ?Closure $connectionHandler,
+                        ?Closure $requestHandler,
+                        ?Closure $upgradeHandler,
+                        ?Closure $messageHandler,
+                        ?Closure $closeHandler,
+                        ?Closure $exceptionHandler,
+                        private H2Connection $protocol,
+                    ) {
+                        parent::__construct($connectionHandler, $requestHandler, $upgradeHandler, $messageHandler, $closeHandler, $exceptionHandler);
+                    }
+
+                    protected function createH2ServerConnectionFromSocket(Socket $socket, array $serverParams = []): H2ServerConnection
+                    {
+                        return new H2ServerConnection(connection: $this->protocol);
+                    }
+                };
+            }
+        );
+
+        $driver->runAcceptedConnection($httpConnection);
+
+        $this->assertSame(101, $httpConnection->switchHeaders['status']);
+        $this->assertSame('h2c', $httpConnection->switchHeaders['headers']['Upgrade']);
+        $this->assertTrue($protocol->isInitialized());
+        $this->assertCount(4, $protocol->writtenFrames);
+        $this->assertSame(H2Frame::TYPE_SETTINGS, $protocol->writtenFrames[0]->type);
+        $this->assertSame(H2Frame::TYPE_SETTINGS, $protocol->writtenFrames[1]->type);
+        $this->assertSame(H2Frame::FLAG_ACK, $protocol->writtenFrames[1]->flags);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $protocol->writtenFrames[2]->type);
+        $this->assertSame(H2Frame::TYPE_DATA, $protocol->writtenFrames[3]->type);
+    }
+
+    public function testEventDriverHandlesH2cUpgradeRequestBodyAndSubsequentStream(): void
+    {
+        $protocol = $this->createH2ProtocolWithFrames([
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 3, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ]);
+        $request = Psr7::createServerRequest(
+            'POST',
+            '/h2c',
+            [],
+            [
+                'Connection' => 'Upgrade, HTTP2-Settings',
+                'Upgrade' => 'h2c',
+                'HTTP2-Settings' => 'AAMAAABk',
+            ],
+            'upgrade-body',
+        );
+        $request->setIsUpgrade(true);
+        $httpConnection = new class(new Server(), $request) extends ServerConnection {
+            public ?array $switchHeaders = null;
+
+            public function __construct(Server $server, private ServerRequestInterface $request)
+            {
+                parent::__construct($server);
+            }
+
+            public function peekString(int $size = 8192, ?int $timeout = 0): string
+            {
+                return 'POST /h2c HTTP/1.1';
+            }
+
+            public function recvHttpRequest(?int $timeout = null): ServerRequestInterface
+            {
+                return $this->request;
+            }
+
+            public function sendHttpHeader(int $statusCode = 200, string $reasonPhrase = '', array $headers = [], string $protocolVersion = '1.1'): static
+            {
+                $this->switchHeaders = ['status' => $statusCode, 'headers' => $headers];
+                return $this;
+            }
+        };
+        $requests = [];
+        $driver = $this->createEventDriverRunnerWithOverrides(
+            static function ($connection, ServerRequestInterface $request) use (&$requests): string {
+                $requests[] = [
+                    'method' => $request->getMethod(),
+                    'path' => $request->getUri()->getPath(),
+                    'body' => (string) $request->getBody(),
+                ];
+                return 'ok';
+            },
+            static function (?Closure $connectionHandler, ?Closure $requestHandler, ?Closure $upgradeHandler, ?Closure $messageHandler, ?Closure $closeHandler, ?Closure $exceptionHandler) use ($protocol): EventDriverConnectionHandler {
+                return new class($connectionHandler, $requestHandler, $upgradeHandler, $messageHandler, $closeHandler, $exceptionHandler, $protocol) extends EventDriverConnectionHandler {
+                    public function __construct(
+                        ?Closure $connectionHandler,
+                        ?Closure $requestHandler,
+                        ?Closure $upgradeHandler,
+                        ?Closure $messageHandler,
+                        ?Closure $closeHandler,
+                        ?Closure $exceptionHandler,
+                        private H2Connection $protocol,
+                    ) {
+                        parent::__construct($connectionHandler, $requestHandler, $upgradeHandler, $messageHandler, $closeHandler, $exceptionHandler);
+                    }
+
+                    protected function createH2ServerConnectionFromSocket(Socket $socket, array $serverParams = []): H2ServerConnection
+                    {
+                        return new H2ServerConnection(connection: $this->protocol);
+                    }
+                };
+            }
+        );
+
+        $driver->runAcceptedConnection($httpConnection);
+
+        $this->assertSame(101, $httpConnection->switchHeaders['status']);
+        $this->assertSame(
+            [
+                ['method' => 'POST', 'path' => '/h2c', 'body' => 'upgrade-body'],
+                ['method' => 'GET', 'path' => '/', 'body' => ''],
+            ],
+            $requests
+        );
+        $this->assertCount(6, $protocol->writtenFrames);
+    }
+
+    public function testEventDriverRejectsInvalidH2cSettingsPayload(): void
+    {
+        $request = Psr7::createServerRequest(
+            'GET',
+            '/h2c',
+            [],
+            [
+                'Connection' => 'Upgrade, HTTP2-Settings',
+                'Upgrade' => 'h2c',
+                'HTTP2-Settings' => 'invalid',
+            ]
+        );
+        $request->setIsUpgrade(true);
+        $httpConnection = new class(new Server(), $request) extends ServerConnection {
+            public ?array $errorCall = null;
+            public bool $closed = false;
+
+            public function __construct(Server $server, private ServerRequestInterface $request)
+            {
+                parent::__construct($server);
+            }
+
+            public function peekString(int $size = 8192, ?int $timeout = 0): string
+            {
+                return 'GET /h2c HTTP/1.1';
+            }
+
+            public function recvHttpRequest(?int $timeout = null): ServerRequestInterface
+            {
+                return $this->request;
+            }
+
+            public function error(int $statusCode, string $message = '', ?bool $close = null): void
+            {
+                $this->errorCall = ['status' => $statusCode, 'message' => $message, 'close' => $close];
+            }
+
+            public function close(): bool
+            {
+                $this->closed = true;
+                return true;
+            }
+        };
+        $driver = $this->createEventDriverRunner(
+            static function () {
+                throw new RuntimeException('request handler should not be called');
+            }
+        );
+
+        $driver->runAcceptedConnection($httpConnection);
+
+        $this->assertSame(400, $httpConnection->errorCall['status']);
+        $this->assertSame(true, $httpConnection->errorCall['close']);
+        $this->assertTrue($httpConnection->closed);
+    }
+
+    private function createEventDriverRunner(callable $requestHandler): EventDriver
+    {
+        return $this->createEventDriverRunnerWithOverrides($requestHandler, null);
+    }
+
+    private function createEventDriverRunnerWithOverrides(callable $requestHandler, ?callable $factory): EventDriver
+    {
+        $driver = (new class extends EventDriver {
+            public $factory = null;
+
+            public function runAcceptedConnection(ServerConnection|H2ServerConnection $connection): void
+            {
+                $this->createRuntimeHandler()->handle($connection);
+            }
+
+            private function createRuntimeHandler(): EventDriverConnectionHandler
+            {
+                if ($this->factory !== null) {
+                    return ($this->factory)(
+                        isset($this->connectionHandler) ? $this->connectionHandler : null,
+                        isset($this->requestHandler) ? $this->requestHandler : null,
+                        isset($this->upgradeHandler) ? $this->upgradeHandler : null,
+                        isset($this->messageHandler) ? $this->messageHandler : null,
+                        isset($this->closeHandler) ? $this->closeHandler : null,
+                        isset($this->exceptionHandler) ? $this->exceptionHandler : null,
+                    );
+                }
+
+                return $this->createConnectionHandler(
+                    isset($this->connectionHandler) ? $this->connectionHandler : null,
+                    isset($this->requestHandler) ? $this->requestHandler : null,
+                    isset($this->upgradeHandler) ? $this->upgradeHandler : null,
+                    isset($this->messageHandler) ? $this->messageHandler : null,
+                    isset($this->closeHandler) ? $this->closeHandler : null,
+                    isset($this->exceptionHandler) ? $this->exceptionHandler : null,
+                );
+            }
+        })->withRequestHandler($requestHandler);
+        $driver->factory = $factory;
+
+        return $driver;
+    }
+
+    /**
+     * @param list<H2Frame> $frames
+     */
+    private function createH2ProtocolWithFrames(array $frames): H2Connection
+    {
+        return new class(new Socket(Socket::TYPE_TCP), $frames) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames;
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+            public int $prefaceReads = 0;
+            public bool $initialized = false;
+
+            /**
+             * @param list<H2Frame> $frames
+             */
+            public function __construct(Socket $socket, array $frames)
+            {
+                parent::__construct($socket);
+                $this->readFrames = $frames;
+            }
+
+            public function readClientPreface(?int $timeout = null): void
+            {
+                $this->prefaceReads++;
+            }
+
+            public function initialize(?int $timeout = null, array $settings = []): void
+            {
+                $this->initialized = true;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+    }
+}

--- a/lib/swow-library/tests/Psr7/Server/H2ServerConnectionTest.php
+++ b/lib/swow-library/tests/Psr7/Server/H2ServerConnectionTest.php
@@ -1,0 +1,387 @@
+<?php
+
+/**
+ * This file is part of Swow
+ *
+ * @link    https://github.com/swow/swow
+ * @contact twosee <twosee@php.net>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code
+ */
+
+declare(strict_types=1);
+
+namespace Swow\Tests\Psr7\Server;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Swow\Http\Protocol\H2Connection;
+use Swow\Http\Protocol\H2Exception;
+use Swow\Http\Protocol\H2Frame;
+use Swow\Http\Protocol\H2Headers;
+use Swow\Psr7\Message\ServerRequest;
+use Swow\Psr7\Server\H2ServerConnection;
+use Swow\Socket;
+
+/**
+ * @internal
+ */
+#[CoversClass(H2Headers::class)]
+#[CoversClass(H2ServerConnection::class)]
+#[CoversClass(H2Connection::class)]
+final class H2ServerConnectionTest extends TestCase
+{
+    public function testRecvRequestFromHeadersCreatesServerRequest(): void
+    {
+        $connection = new H2ServerConnection();
+        $request = $connection->recvRequestFromHeaders([
+            [':method', 'GET'],
+            [':scheme', 'https'],
+            [':authority', 'example.com'],
+            [':path', '/hello?foo=bar'],
+            ['accept', 'application/json'],
+            ['cookie', 'a=1; b=2'],
+        ]);
+
+        $this->assertInstanceOf(ServerRequest::class, $request);
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('https://example.com/hello?foo=bar', (string) $request->getUri());
+        $this->assertSame('application/json', $request->getHeaderLine('accept'));
+        $this->assertSame('example.com', $request->getHeaderLine('host'));
+        $this->assertSame('1', $request->getCookieParams()['a']);
+        $this->assertSame('2', $request->getCookieParams()['b']);
+        $this->assertSame('2.0', $request->getProtocolVersion());
+    }
+
+    public function testRecvRequestFromHeadersRejectsMissingPseudoHeader(): void
+    {
+        $connection = new H2ServerConnection();
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Missing required pseudo-header ":method"');
+
+        $connection->recvRequestFromHeaders([
+            [':scheme', 'https'],
+            [':authority', 'example.com'],
+            [':path', '/'],
+        ]);
+    }
+
+    public function testRecvRequestFromHeadersSupportsConnectWithoutPath(): void
+    {
+        $connection = new H2ServerConnection();
+        $request = $connection->recvRequestFromHeaders([
+            [':method', 'CONNECT'],
+            [':authority', 'example.com:443'],
+        ]);
+
+        $this->assertSame('CONNECT', $request->getMethod());
+        $this->assertSame('example.com:443', $request->getHeaderLine('host'));
+    }
+
+    public function testTryRecvStreamRequestReturnsNullWhenNoMoreRequestStreamsAllowed(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->validateFrame(new H2Frame(H2Frame::TYPE_GOAWAY, 0, 0, pack('NN', 0, H2Exception::ERROR_NO_ERROR)));
+            }
+        };
+
+        $connection = new H2ServerConnection(connection: $queuedConnection);
+
+        $this->assertNull($connection->tryRecvStreamRequest());
+    }
+
+    public function testSendResponseHeadersAndDataWriteFrames(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseHeaders(1, 200, ['content-type' => 'text/plain']);
+        $connection->sendResponseData(1, 'hello', true);
+
+        $this->assertCount(2, $recordingConnection->frames);
+        $headersFrame = $recordingConnection->frames[0];
+        $dataFrame = $recordingConnection->frames[1];
+
+        $this->assertSame(H2Frame::TYPE_HEADERS, $headersFrame->type);
+        $this->assertSame(H2Frame::FLAG_END_HEADERS, $headersFrame->flags);
+        $this->assertSame(1, $headersFrame->streamId);
+        $this->assertNotSame('', $headersFrame->payload);
+
+        $this->assertSame(H2Frame::TYPE_DATA, $dataFrame->type);
+        $this->assertSame(H2Frame::FLAG_END_STREAM, $dataFrame->flags);
+        $this->assertSame(1, $dataFrame->streamId);
+        $this->assertSame('hello', $dataFrame->payload);
+    }
+
+    public function testSendResponseDataSplitsPayloadLargerThanSingleFrameLimit(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $payload = str_repeat('a', H2Frame::DEFAULT_MAX_FRAME_SIZE + 1);
+
+        $connection->sendResponseData(1, $payload, true);
+
+        $this->assertCount(2, $recordingConnection->frames);
+
+        $firstFrame = $recordingConnection->frames[0];
+        $lastFrame = $recordingConnection->frames[1];
+
+        $this->assertSame(H2Frame::TYPE_DATA, $firstFrame->type);
+        $this->assertSame(0, $firstFrame->flags);
+        $this->assertSame(H2Frame::DEFAULT_MAX_FRAME_SIZE, strlen($firstFrame->payload));
+
+        $this->assertSame(H2Frame::TYPE_DATA, $lastFrame->type);
+        $this->assertSame(H2Frame::FLAG_END_STREAM, $lastFrame->flags);
+        $this->assertSame(1, strlen($lastFrame->payload));
+        $this->assertSame($payload, $firstFrame->payload . $lastFrame->payload);
+    }
+
+    public function testSendResponseHeadersUsesNegotiatedMaxFrameSize(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->validateFrame(new H2Frame(H2Frame::TYPE_SETTINGS, 0, 0, pack('nN', 0x5, 32768)));
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseHeaders(1, 200, ['x-long' => str_repeat('a', 20000)]);
+
+        $this->assertCount(1, $recordingConnection->frames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $recordingConnection->frames[0]->type);
+        $this->assertSame(1, $recordingConnection->frames[0]->streamId);
+    }
+
+    public function testSendResponseHeadersSplitsPayloadExceedingNegotiatedMaxFrameSize(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->validateFrame(new H2Frame(H2Frame::TYPE_SETTINGS, 0, 0, pack('nN', 0x5, 20000)));
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseHeaders(1, 200, ['x-long' => str_repeat('b', 21000)]);
+
+        $this->assertCount(2, $recordingConnection->frames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $recordingConnection->frames[0]->type);
+        $this->assertSame(1, $recordingConnection->frames[0]->streamId);
+        $this->assertSame(0, $recordingConnection->frames[0]->flags & H2Frame::FLAG_END_HEADERS);
+        $this->assertSame(H2Frame::TYPE_CONTINUATION, $recordingConnection->frames[1]->type);
+        $this->assertSame(H2Frame::FLAG_END_HEADERS, $recordingConnection->frames[1]->flags);
+    }
+
+    public function testSendResponseHeadersSetsEndStreamOnlyOnFirstHeadersFrameWhenSplit(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->validateFrame(new H2Frame(H2Frame::TYPE_SETTINGS, 0, 0, pack('nN', 0x5, 20000)));
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseHeaders(1, 200, ['x-long' => str_repeat('c', 21000)], true);
+
+        $this->assertCount(2, $recordingConnection->frames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $recordingConnection->frames[0]->type);
+        $this->assertSame(H2Frame::FLAG_END_STREAM, $recordingConnection->frames[0]->flags & H2Frame::FLAG_END_STREAM);
+        $this->assertSame(H2Frame::TYPE_CONTINUATION, $recordingConnection->frames[1]->type);
+        $this->assertSame(0, $recordingConnection->frames[1]->flags & H2Frame::FLAG_END_STREAM);
+        $this->assertSame(H2Frame::FLAG_END_HEADERS, $recordingConnection->frames[1]->flags);
+    }
+
+    public function testSendResponseHeadersDoesNotConsumeSendWindows(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->connectionSendWindow = 100;
+                $this->streamSendWindows[1] = 100;
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+
+            public function exposeConnectionSendWindow(): int
+            {
+                return $this->connectionSendWindow;
+            }
+
+            public function exposeStreamSendWindow(int $streamId): int
+            {
+                return $this->streamSendWindows[$streamId] ?? self::DEFAULT_INITIAL_WINDOW_SIZE;
+            }
+        };
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseHeaders(1, 200, ['x-a' => 'b']);
+
+        $this->assertCount(1, $recordingConnection->frames);
+        $this->assertSame(100, $recordingConnection->exposeConnectionSendWindow());
+        $this->assertSame(100, $recordingConnection->exposeStreamSendWindow(1));
+    }
+
+    public function testSendResponseHeadersIgnoresConnectionSendWindow(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->connectionSendWindow = 1;
+                $this->streamSendWindows[1] = 100;
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseHeaders(1, 200, ['x-a' => 'b']);
+
+        $this->assertCount(1, $recordingConnection->frames);
+    }
+
+    public function testSendResponseHeadersIgnoresStreamSendWindow(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->connectionSendWindow = 100;
+                $this->streamSendWindows[1] = 1;
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseHeaders(1, 200, ['x-a' => 'b']);
+
+        $this->assertCount(1, $recordingConnection->frames);
+    }
+
+    public function testSendResponseHeadersAllowsNewStreamWhenInitialWindowSizeIsZero(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->validateFrame(new H2Frame(H2Frame::TYPE_SETTINGS, 0, 0, pack('nN', 0x4, 0)));
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseHeaders(3, 200, ['x-a' => 'b']);
+
+        $this->assertCount(1, $recordingConnection->frames);
+        $this->assertSame(3, $recordingConnection->frames[0]->streamId);
+    }
+
+    public function testSendResponseHeadersAllowsSmallHeaderBlockWithinReducedInitialWindowSize(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->validateFrame(new H2Frame(H2Frame::TYPE_SETTINGS, 0, 0, pack('nN', 0x4, 20)));
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseHeaders(5, 200, ['x-a' => 'b']);
+
+        $this->assertCount(1, $recordingConnection->frames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $recordingConnection->frames[0]->type);
+        $this->assertSame(5, $recordingConnection->frames[0]->streamId);
+    }
+
+    public function testSendResponseTrailersSendsHeadersEndStream(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseTrailers(1, ['x-trailer' => 'done']);
+
+        $this->assertCount(1, $recordingConnection->frames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $recordingConnection->frames[0]->type);
+        $this->assertSame(H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, $recordingConnection->frames[0]->flags);
+    }
+
+    public function testSendResponseTrailersRejectsPseudoHeaders(): void
+    {
+        $connection = new H2ServerConnection(connection: new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {});
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Trailer headers must not contain pseudo-headers');
+
+        $connection->sendResponseTrailers(1, [':status' => '200']);
+    }
+}

--- a/lib/swow-library/tests/Psr7/Server/H2ServerFactoryTest.php
+++ b/lib/swow-library/tests/Psr7/Server/H2ServerFactoryTest.php
@@ -1,0 +1,479 @@
+<?php
+
+/**
+ * This file is part of Swow
+ *
+ * @link    https://github.com/swow/swow
+ * @contact twosee <twosee@php.net>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code
+ */
+
+declare(strict_types=1);
+
+namespace Swow\Tests\Psr7\Server;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Swow\Http\Protocol\H2Connection;
+use Swow\Http\Protocol\H2Exception;
+use Swow\Coroutine;
+use Swow\Http\Protocol\H2Frame;
+use Swow\Psr7\Psr7;
+use Swow\Psr7\Server\H2ServerConnection;
+use Swow\Psr7\Server\H2ServerConnectionFactory;
+use Swow\Psr7\Server\Server;
+use Swow\Psr7\Server\ServerConnection;
+use Swow\Socket;
+use Swow\SocketException;
+use Swow\Sync\WaitReference;
+
+/**
+ * @internal
+ */
+#[CoversClass(H2ServerConnectionFactory::class)]
+#[CoversClass(H2ServerConnection::class)]
+final class H2ServerFactoryTest extends TestCase
+{
+    public function testServerAcceptConnectionReturnsH2ConnectionWhenUsingH2Factory(): void
+    {
+        $server = new Server();
+        $server->setServerConnectionFactory(new H2ServerConnectionFactory());
+        try {
+            $server->bind('127.0.0.1')->listen();
+        } catch (SocketException $exception) {
+            $this->markTestSkipped('Socket bind is not permitted in current environment: ' . $exception->getMessage());
+        }
+
+        $wr = new WaitReference();
+        $acceptedConnection = null;
+        Coroutine::run(static function () use ($server, &$acceptedConnection, $wr): void {
+            $acceptedConnection = $server->acceptConnection();
+        });
+
+        $client = new Socket(Socket::TYPE_TCP);
+        $client->connect($server->getSockAddress(), $server->getSockPort());
+
+        $wr::wait($wr);
+
+        $this->assertInstanceOf(H2ServerConnection::class, $acceptedConnection);
+        $this->assertSame($client->getSockAddress(), $acceptedConnection->getServerParams()['remote_addr']);
+        $this->assertSame($client->getSockPort(), $acceptedConnection->getServerParams()['remote_port']);
+
+        $client->close();
+        $acceptedConnection?->close();
+        $server->close();
+    }
+
+    public function testServerAcceptConnectionStillReturnsHttpConnectionByDefault(): void
+    {
+        $server = new Server();
+        try {
+            $server->bind('127.0.0.1')->listen();
+        } catch (SocketException $exception) {
+            $this->markTestSkipped('Socket bind is not permitted in current environment: ' . $exception->getMessage());
+        }
+
+        $wr = new WaitReference();
+        $acceptedConnection = null;
+        Coroutine::run(static function () use ($server, &$acceptedConnection, $wr): void {
+            $acceptedConnection = $server->acceptConnection();
+        });
+
+        $client = new Socket(Socket::TYPE_TCP);
+        $client->connect($server->getSockAddress(), $server->getSockPort());
+
+        $wr::wait($wr);
+
+        $this->assertInstanceOf(ServerConnection::class, $acceptedConnection);
+
+        $client->close();
+        $acceptedConnection?->close();
+        $server->close();
+    }
+
+    public function testH2ConnectionServeRunsPrefaceInitializeAndHandler(): void
+    {
+        $protocol = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+            public int $prefaceReads = 0;
+            /** @var array{timeout: ?int, settings: array<int,int>}|null */
+            public ?array $initializeCall = null;
+
+            public function readClientPreface(?int $timeout = null): void
+            {
+                $this->prefaceReads++;
+            }
+
+            public function initialize(?int $timeout = null, array $settings = []): void
+            {
+                $this->initializeCall = ['timeout' => $timeout, 'settings' => $settings];
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+        $protocol->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ];
+
+        $connection = new H2ServerConnection(connection: $protocol);
+        $handled = $connection->serve(
+            static fn($request, int $streamId) => Psr7::createResponse(204),
+            ['settings' => [H2Connection::SETTINGS_MAX_FRAME_SIZE => 32768], 'limit' => 1]
+        );
+
+        $this->assertSame(1, $handled);
+        $this->assertSame(1, $protocol->prefaceReads);
+        $this->assertSame(['timeout' => null, 'settings' => [H2Connection::SETTINGS_MAX_FRAME_SIZE => 32768]], $protocol->initializeCall);
+        $this->assertCount(1, $protocol->writtenFrames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $protocol->writtenFrames[0]->type);
+    }
+
+    public function testServerHandleH2ConnectionUsesAcceptedH2Connection(): void
+    {
+        $protocol = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+            public int $prefaceReads = 0;
+
+            public function readClientPreface(?int $timeout = null): void
+            {
+                $this->prefaceReads++;
+            }
+
+            public function initialize(?int $timeout = null, array $settings = []): void
+            {
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+        $protocol->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ];
+        $acceptedConnection = new H2ServerConnection(connection: $protocol);
+
+        $server = new class($acceptedConnection) extends Server {
+            public function __construct(private H2ServerConnection $acceptedConnection)
+            {
+                parent::__construct();
+            }
+
+            public function acceptConnection(?int $timeout = null): ServerConnection|H2ServerConnection
+            {
+                return $this->acceptedConnection;
+            }
+        };
+
+        $handled = $server->handleH2Connection(
+            static fn($request, int $streamId) => Psr7::createResponse(204),
+            ['limit' => 1]
+        );
+
+        $this->assertSame(1, $handled);
+        $this->assertSame(1, $protocol->prefaceReads);
+        $this->assertCount(1, $protocol->writtenFrames);
+    }
+
+    public function testServerHandleH2ConnectionAcceptsNamedResponseMapWithTrailers(): void
+    {
+        $protocol = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+
+            public function readClientPreface(?int $timeout = null): void
+            {
+            }
+
+            public function initialize(?int $timeout = null, array $settings = []): void
+            {
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+        $protocol->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ];
+        $acceptedConnection = new H2ServerConnection(connection: $protocol);
+
+        $server = new class($acceptedConnection) extends Server {
+            public function __construct(private H2ServerConnection $acceptedConnection)
+            {
+                parent::__construct();
+            }
+
+            public function acceptConnection(?int $timeout = null): ServerConnection|H2ServerConnection
+            {
+                return $this->acceptedConnection;
+            }
+        };
+
+        $handled = $server->handleH2Connection(
+            static fn($request, int $streamId): array => [
+                'status' => 202,
+                'headers' => ['x-server' => 'yes'],
+                'body' => 'ok',
+                'trailers' => ['x-trailer' => 'done'],
+            ],
+            ['limit' => 1]
+        );
+
+        $this->assertSame(1, $handled);
+        $this->assertCount(3, $protocol->writtenFrames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $protocol->writtenFrames[0]->type);
+        $this->assertSame(H2Frame::TYPE_DATA, $protocol->writtenFrames[1]->type);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $protocol->writtenFrames[2]->type);
+    }
+
+    public function testServerHandleH2ConnectionRejectsDefaultHttpConnection(): void
+    {
+        $server = new class extends Server {
+            public function acceptConnection(?int $timeout = null): ServerConnection|H2ServerConnection
+            {
+                return new ServerConnection($this);
+            }
+        };
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Accepted connection is not an H2 server connection');
+
+        $server->handleH2Connection(static fn($request, int $streamId) => Psr7::createResponse(204));
+    }
+
+    public function testServerHandleH2ConnectionAcceptsArrayResponseLikeEventDriver(): void
+    {
+        $protocol = $this->createProtocolWithFrames([
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ]);
+        $acceptedConnection = new H2ServerConnection(connection: $protocol);
+        $server = $this->createAcceptedH2Server($acceptedConnection);
+
+        $handled = $server->handleH2Connection(
+            static fn(ServerRequestInterface $request, int $streamId): array => [203, ['x-handle' => 'server'], 'handled'],
+            ['limit' => 1]
+        );
+
+        $this->assertSame(1, $handled);
+        $this->assertCount(2, $protocol->writtenFrames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $protocol->writtenFrames[0]->type);
+        $this->assertSame(H2Frame::TYPE_DATA, $protocol->writtenFrames[1]->type);
+        $this->assertSame('handled', $protocol->writtenFrames[1]->payload);
+    }
+
+    public function testServerHandleH2ConnectionStopsNaturallyOnEofLikeEventDriver(): void
+    {
+        $protocol = $this->createProtocolWithFrames([]);
+        $acceptedConnection = new H2ServerConnection(connection: $protocol);
+        $server = $this->createAcceptedH2Server($acceptedConnection);
+
+        $handled = $server->handleH2Connection(
+            static fn(ServerRequestInterface $request, int $streamId): ResponseInterface => Psr7::createResponse(204)
+        );
+
+        $this->assertSame(0, $handled);
+        $this->assertSame(1, $protocol->prefaceReads);
+        $this->assertTrue($protocol->initialized);
+    }
+
+    public function testServerHandleH2ConnectionPropagatesConnectionLevelErrorsLikeEventDriver(): void
+    {
+        $protocol = $this->createProtocolWithFrames([
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ]);
+        $acceptedConnection = new H2ServerConnection(connection: $protocol);
+        $server = $this->createAcceptedH2Server($acceptedConnection);
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('connection-failed');
+
+        $server->handleH2Connection(
+            static function (ServerRequestInterface $request, int $streamId) {
+                throw H2Exception::forConnectionError('connection-failed');
+            },
+            ['limit' => 1]
+        );
+    }
+
+    public function testServerHandleH2ConnectionRejectsNullResponse(): void
+    {
+        $protocol = $this->createProtocolWithFrames([
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ]);
+        $acceptedConnection = new H2ServerConnection(connection: $protocol);
+        $server = $this->createAcceptedH2Server($acceptedConnection);
+
+        $this->expectException(\TypeError::class);
+
+        $server->handleH2Connection(
+            static fn(ServerRequestInterface $request, int $streamId) => null,
+            ['limit' => 1]
+        );
+    }
+
+    public function testServerHandleH2ConnectionAcceptsStatusOnlyResponse(): void
+    {
+        $protocol = $this->createProtocolWithFrames([
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ]);
+        $acceptedConnection = new H2ServerConnection(connection: $protocol);
+        $server = $this->createAcceptedH2Server($acceptedConnection);
+
+        $handled = $server->handleH2Connection(
+            static fn(ServerRequestInterface $request, int $streamId): int => 204,
+            ['limit' => 1]
+        );
+
+        $this->assertSame(1, $handled);
+        $this->assertCount(1, $protocol->writtenFrames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $protocol->writtenFrames[0]->type);
+        $this->assertSame(H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, $protocol->writtenFrames[0]->flags);
+    }
+
+    public function testServerHandleH2ConnectionAcceptsBodyOnlyResponse(): void
+    {
+        $protocol = $this->createProtocolWithFrames([
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ]);
+        $acceptedConnection = new H2ServerConnection(connection: $protocol);
+        $server = $this->createAcceptedH2Server($acceptedConnection);
+
+        $handled = $server->handleH2Connection(
+            static fn(ServerRequestInterface $request, int $streamId): string => 'body-only',
+            ['limit' => 1]
+        );
+
+        $this->assertSame(1, $handled);
+        $this->assertCount(2, $protocol->writtenFrames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $protocol->writtenFrames[0]->type);
+        $this->assertSame(H2Frame::TYPE_DATA, $protocol->writtenFrames[1]->type);
+        $this->assertSame('body-only', $protocol->writtenFrames[1]->payload);
+    }
+
+    public function testServerHandleH2ConnectionRejectsUnsupportedResponseValue(): void
+    {
+        $protocol = $this->createProtocolWithFrames([
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ]);
+        $acceptedConnection = new H2ServerConnection(connection: $protocol);
+        $server = $this->createAcceptedH2Server($acceptedConnection);
+
+        $this->expectException(\TypeError::class);
+
+        $server->handleH2Connection(
+            static fn(ServerRequestInterface $request, int $streamId): object => new \stdClass(),
+            ['limit' => 1]
+        );
+    }
+
+    private function createAcceptedH2Server(H2ServerConnection $acceptedConnection): Server
+    {
+        return new class($acceptedConnection) extends Server {
+            public function __construct(private H2ServerConnection $acceptedConnection)
+            {
+                parent::__construct();
+            }
+
+            public function acceptConnection(?int $timeout = null): ServerConnection|H2ServerConnection
+            {
+                return $this->acceptedConnection;
+            }
+        };
+    }
+
+    /**
+     * @param list<H2Frame> $frames
+     */
+    private function createProtocolWithFrames(array $frames): H2Connection
+    {
+        return new class(new Socket(Socket::TYPE_TCP), $frames) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames;
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+            public int $prefaceReads = 0;
+            public bool $initialized = false;
+
+            /**
+             * @param list<H2Frame> $frames
+             */
+            public function __construct(Socket $socket, array $frames)
+            {
+                parent::__construct($socket);
+                $this->readFrames = $frames;
+            }
+
+            public function readClientPreface(?int $timeout = null): void
+            {
+                $this->prefaceReads++;
+            }
+
+            public function initialize(?int $timeout = null, array $settings = []): void
+            {
+                $this->initialized = true;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+    }
+}

--- a/lib/swow-library/tests/Psr7/Server/H2ServerRequestBodyFlowTest.php
+++ b/lib/swow-library/tests/Psr7/Server/H2ServerRequestBodyFlowTest.php
@@ -1,0 +1,609 @@
+<?php
+
+/**
+ * This file is part of Swow
+ *
+ * @link    https://github.com/swow/swow
+ * @contact twosee <twosee@php.net>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code
+ */
+
+declare(strict_types=1);
+
+namespace Swow\Tests\Psr7\Server;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Swow\Http\Protocol\H2Connection;
+use Swow\Http\Protocol\H2Exception;
+use Swow\Http\Protocol\H2Frame;
+use Swow\Psr7\Server\H2ServerConnection;
+use Swow\Socket;
+
+/**
+ * @internal
+ */
+#[CoversClass(H2ServerConnection::class)]
+#[CoversClass(H2Connection::class)]
+final class H2ServerRequestBodyFlowTest extends TestCase
+{
+    public function testRecvRequestWithoutBodyWhenHeadersEndStreamIsSet(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $queuedConnection->frames = [
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM,
+                1,
+                "\x82\x87\x41\x0bexample.com\x44\x01/"
+            ),
+        ];
+
+        $connection = new H2ServerConnection(connection: $queuedConnection);
+        $request = $connection->recvRequest();
+
+        $this->assertSame('', (string) $request->getBody());
+    }
+
+    public function testRecvRequestWithSingleDataFrameBody(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $queuedConnection->frames = [
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS,
+                1,
+                "\x82\x87\x41\x0bexample.com\x44\x05/echo"
+            ),
+            new H2Frame(H2Frame::TYPE_DATA, H2Frame::FLAG_END_STREAM, 1, 'hello'),
+        ];
+
+        $connection = new H2ServerConnection(connection: $queuedConnection);
+        $request = $connection->recvRequest();
+
+        $this->assertSame('hello', (string) $request->getBody());
+    }
+
+    public function testRecvStreamRequestWithBodyReturnsStreamIdAndBody(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $queuedConnection->frames = [
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS,
+                1,
+                "\x82\x87\x41\x0bexample.com\x44\x05/echo"
+            ),
+            new H2Frame(H2Frame::TYPE_DATA, H2Frame::FLAG_END_STREAM, 1, 'hello'),
+        ];
+
+        $connection = new H2ServerConnection(connection: $queuedConnection);
+        $result = $connection->recvStreamRequest();
+
+        $this->assertSame(1, $result['streamId']);
+        $this->assertSame('hello', (string) $result['request']->getBody());
+    }
+
+    public function testRecvRequestWithMultipleDataFramesBody(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $queuedConnection->frames = [
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS,
+                1,
+                "\x82\x87\x41\x0bexample.com\x44\x05/echo"
+            ),
+            new H2Frame(H2Frame::TYPE_DATA, 0, 1, 'hel'),
+            new H2Frame(H2Frame::TYPE_DATA, H2Frame::FLAG_END_STREAM, 1, 'lo'),
+        ];
+
+        $connection = new H2ServerConnection(connection: $queuedConnection);
+        $request = $connection->recvRequest();
+
+        $this->assertSame('hello', (string) $request->getBody());
+    }
+
+    public function testRecvRequestDefersDifferentStreamFramesUntilCurrentBodyCompletes(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $queuedConnection->frames = [
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS,
+                1,
+                "\x82\x87\x41\x0bexample.com\x44\x05/echo"
+            ),
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM,
+                3,
+                "\x82\x87\x41\x0bexample.com\x44\x05/next"
+            ),
+            new H2Frame(H2Frame::TYPE_DATA, H2Frame::FLAG_END_STREAM, 1, 'oops'),
+        ];
+
+        $connection = new H2ServerConnection(connection: $queuedConnection);
+        $firstRequest = $connection->recvRequest();
+        $secondRequest = $connection->recvRequest();
+
+        $this->assertSame('oops', (string) $firstRequest->getBody());
+        $this->assertSame('/next', $secondRequest->getUri()->getPath());
+    }
+
+    public function testRecvRequestDefersDifferentStreamHeaderBlockUntilCurrentBodyCompletes(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $queuedConnection->frames = [
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS,
+                1,
+                "\x82\x87\x41\x0bexample.com\x44\x05/echo"
+            ),
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                0,
+                3,
+                "\x82\x87"
+            ),
+            new H2Frame(
+                H2Frame::TYPE_CONTINUATION,
+                H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM,
+                3,
+                "\x41\x0bexample.com\x44\x05/next"
+            ),
+            new H2Frame(H2Frame::TYPE_DATA, H2Frame::FLAG_END_STREAM, 1, 'body'),
+        ];
+
+        $connection = new H2ServerConnection(connection: $queuedConnection);
+        $firstRequest = $connection->recvRequest();
+        $secondRequest = $connection->recvRequest();
+
+        $this->assertSame('body', (string) $firstRequest->getBody());
+        $this->assertSame('/next', $secondRequest->getUri()->getPath());
+    }
+
+    public function testRecvRequestSendsRstStreamOnStreamLevelBodyError(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+            /** @var list<H2Frame> */
+            public array $sentFrames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->sentFrames[] = $frame;
+            }
+        };
+        $queuedConnection->validateFrame(new H2Frame(H2Frame::TYPE_SETTINGS, 0, 0, pack('nN', 0x4, 2)));
+        $queuedConnection->frames = [
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS,
+                1,
+                "\x82\x87\x41\x0bexample.com\x44\x05/echo"
+            ),
+            new H2Frame(H2Frame::TYPE_DATA, H2Frame::FLAG_END_STREAM, 1, 'abc'),
+        ];
+
+        $connection = new H2ServerConnection(connection: $queuedConnection);
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Stream receive window exhausted');
+
+        try {
+            $connection->recvRequest();
+        } finally {
+            $this->assertCount(1, $queuedConnection->sentFrames);
+            $this->assertSame(H2Frame::TYPE_RST_STREAM, $queuedConnection->sentFrames[0]->type);
+            $this->assertSame(1, $queuedConnection->sentFrames[0]->streamId);
+            $this->assertSame(pack('N', H2Exception::ERROR_FLOW_CONTROL_ERROR), $queuedConnection->sentFrames[0]->payload);
+        }
+    }
+
+    public function testRecvRequestAllowsBodyDrainForExistingStreamAfterGoAway(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+        };
+        $queuedConnection->markRequestStreamProcessed(1);
+        $queuedConnection->validateFrame(new H2Frame(H2Frame::TYPE_GOAWAY, 0, 0, pack('NN', 1, H2Exception::ERROR_NO_ERROR)));
+        $queuedConnection->frames = [
+            new H2Frame(H2Frame::TYPE_DATA, H2Frame::FLAG_END_STREAM, 1, 'hello'),
+        ];
+
+        $body = $queuedConnection->readRequestBody(1);
+
+        $this->assertSame('hello', $body);
+    }
+
+    public function testReadRequestBodyRejectsWhenRemoteSideAlreadyClosed(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+        };
+        $queuedConnection->frames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82"),
+        ];
+        $queuedConnection->readHeaderBlock();
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Cannot receive DATA on remotely closed stream');
+
+        $queuedConnection->readRequestBody(1);
+    }
+
+    public function testRecvRequestStoresTrailingHeadersInRequestAttributes(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $queuedConnection->frames = [
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS,
+                1,
+                "\x82\x87\x41\x0bexample.com\x44\x05/echo"
+            ),
+            new H2Frame(H2Frame::TYPE_DATA, 0, 1, 'hello'),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x40\x0ax-trailing\x03yes"),
+        ];
+
+        $connection = new H2ServerConnection(connection: $queuedConnection);
+        $request = $connection->recvRequest();
+
+        $this->assertSame('hello', (string) $request->getBody());
+        $this->assertSame(['x-trailing' => ['yes']], H2ServerConnection::getRequestTrailers($request));
+    }
+
+    public function testRecvRequestRejectsTrailingPseudoHeaders(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $queuedConnection->frames = [
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS,
+                1,
+                "\x82\x87\x41\x0bexample.com\x44\x05/echo"
+            ),
+            new H2Frame(H2Frame::TYPE_DATA, 0, 1, 'hello'),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x84"),
+        ];
+
+        $connection = new H2ServerConnection(connection: $queuedConnection);
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Trailer headers must not contain pseudo-headers');
+
+        $connection->recvRequest();
+    }
+
+    public function testRecvRequestDefersDifferentStreamHeaderBlockUntilTrailersComplete(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $queuedConnection->frames = [
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS,
+                1,
+                "\x82\x87\x41\x0bexample.com\x44\x05/echo"
+            ),
+            new H2Frame(H2Frame::TYPE_DATA, 0, 1, 'hello'),
+            new H2Frame(H2Frame::TYPE_HEADERS, 0, 1, "\x40\x0ax-trailing"),
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM,
+                3,
+                "\x82\x87\x41\x0bexample.com\x44\x05/next"
+            ),
+            new H2Frame(H2Frame::TYPE_CONTINUATION, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x03yes"),
+        ];
+
+        $connection = new H2ServerConnection(connection: $queuedConnection);
+        $firstRequest = $connection->recvRequest();
+        $secondRequest = $connection->recvRequest();
+
+        $this->assertSame('hello', (string) $firstRequest->getBody());
+        $this->assertSame(['x-trailing' => ['yes']], H2ServerConnection::getRequestTrailers($firstRequest));
+        $this->assertSame('/next', $secondRequest->getUri()->getPath());
+    }
+
+    public function testRecvRequestRestoresDeferredSplitHeaderBlockAfterControlFramesArePumped(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+            /** @var list<H2Frame> */
+            public array $sentFrames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->sentFrames[] = $frame;
+            }
+        };
+        $queuedConnection->frames = [
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS,
+                1,
+                "\x82\x87\x41\x0bexample.com\x44\x05/echo"
+            ),
+            new H2Frame(H2Frame::TYPE_HEADERS, 0, 3, "\x82\x87"),
+            new H2Frame(H2Frame::TYPE_CONTINUATION, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 3, "\x41\x0bexample.com\x44\x05/next"),
+            new H2Frame(H2Frame::TYPE_PING, 0, 0, '12345678'),
+            new H2Frame(H2Frame::TYPE_DATA, H2Frame::FLAG_END_STREAM, 1, 'body'),
+        ];
+
+        $connection = new H2ServerConnection(connection: $queuedConnection);
+        $firstRequest = $connection->recvRequest();
+        $secondRequest = $connection->recvRequest();
+
+        $this->assertSame('body', (string) $firstRequest->getBody());
+        $this->assertSame('/next', $secondRequest->getUri()->getPath());
+        $this->assertCount(1, $queuedConnection->sentFrames);
+        $this->assertSame(H2Frame::TYPE_PING, $queuedConnection->sentFrames[0]->type);
+        $this->assertSame(H2Frame::FLAG_ACK, $queuedConnection->sentFrames[0]->flags);
+    }
+
+    public function testRecvRequestRejectsTrailerBlockInterruptedByControlFrame(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $queuedConnection->frames = [
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS,
+                1,
+                "\x82\x87\x41\x0bexample.com\x44\x05/echo"
+            ),
+            new H2Frame(H2Frame::TYPE_DATA, 0, 1, 'hello'),
+            new H2Frame(H2Frame::TYPE_HEADERS, 0, 1, "\x40\x0ax-trailing"),
+            new H2Frame(H2Frame::TYPE_PING, 0, 0, '12345678'),
+        ];
+
+        $connection = new H2ServerConnection(connection: $queuedConnection);
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('CONTINUATION frame stream does not match active header block');
+
+        $connection->recvRequest();
+    }
+
+    public function testRecvRequestRejectsTrailerBlockInterruptedByWindowUpdate(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $queuedConnection->frames = [
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS,
+                1,
+                "\x82\x87\x41\x0bexample.com\x44\x05/echo"
+            ),
+            new H2Frame(H2Frame::TYPE_DATA, 0, 1, 'hello'),
+            new H2Frame(H2Frame::TYPE_HEADERS, 0, 1, "\x40\x0ax-trailing"),
+            new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 0, pack('N', 1024)),
+        ];
+
+        $connection = new H2ServerConnection(connection: $queuedConnection);
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('CONTINUATION frame stream does not match active header block');
+
+        $connection->recvRequest();
+    }
+
+    public function testReadRequestBodyAllowsExistingStreamTailAfterGoAwayWhileQueuedNewStreamIsDropped(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+        };
+        $queuedConnection->markRequestStreamProcessed(1);
+        $queuedConnection->validateFrame(new H2Frame(H2Frame::TYPE_GOAWAY, 0, 0, pack('NN', 1, H2Exception::ERROR_NO_ERROR)));
+        $queuedConnection->frames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 3, "\x82\x87\x41\x0bexample.com\x44\x05/dropme"),
+            new H2Frame(H2Frame::TYPE_DATA, H2Frame::FLAG_END_STREAM, 1, 'hello'),
+        ];
+
+        $body = $queuedConnection->readRequestBody(1);
+
+        $this->assertSame('hello', $body);
+        $this->assertNull($queuedConnection->readRequestStartFrame());
+    }
+}

--- a/lib/swow-library/tests/Psr7/Server/H2ServerRequestFlowTest.php
+++ b/lib/swow-library/tests/Psr7/Server/H2ServerRequestFlowTest.php
@@ -1,0 +1,305 @@
+<?php
+
+/**
+ * This file is part of Swow
+ *
+ * @link    https://github.com/swow/swow
+ * @contact twosee <twosee@php.net>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code
+ */
+
+declare(strict_types=1);
+
+namespace Swow\Tests\Psr7\Server;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Swow\Http\Protocol\H2Connection;
+use Swow\Http\Protocol\H2Exception;
+use Swow\Http\Protocol\H2Frame;
+use Swow\Psr7\Message\ServerRequest;
+use Swow\Psr7\Server\H2ServerConnection;
+use Swow\Socket;
+
+/**
+ * @internal
+ */
+#[CoversClass(H2ServerConnection::class)]
+#[CoversClass(H2Connection::class)]
+final class H2ServerRequestFlowTest extends TestCase
+{
+    public function testRecvRequestBuildsServerRequestFromQueuedFrames(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $queuedConnection->frames = [
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM,
+                1,
+                "\x82" .                 // :method GET
+                "\x87" .                 // :scheme https
+                "\x41\x0bexample.com" .  // :authority: example.com
+                "\x44\x06/hello"         // :path: /hello
+            ),
+        ];
+
+        $connection = new H2ServerConnection(connection: $queuedConnection);
+        $request = $connection->recvRequest();
+
+        $this->assertInstanceOf(ServerRequest::class, $request);
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('https://example.com/hello', (string) $request->getUri());
+        $this->assertSame('example.com', $request->getHeaderLine('host'));
+        $this->assertSame('2.0', $request->getProtocolVersion());
+    }
+
+    public function testRecvStreamRequestReturnsStreamIdAndRequest(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $queuedConnection->frames = [
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM,
+                1,
+                "\x82\x87\x41\x0bexample.com\x44\x06/hello"
+            ),
+        ];
+
+        $connection = new H2ServerConnection(connection: $queuedConnection);
+        $result = $connection->recvStreamRequest();
+
+        $this->assertSame(1, $result['streamId']);
+        $this->assertInstanceOf(ServerRequest::class, $result['request']);
+        $this->assertSame('GET', $result['request']->getMethod());
+    }
+
+    public function testRecvStreamRequestPumpsSettingsBeforeHeadersAndSendsAck(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+            /** @var list<H2Frame> */
+            public array $sentFrames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->sentFrames[] = $frame;
+            }
+        };
+        $queuedConnection->frames = [
+            new H2Frame(H2Frame::TYPE_SETTINGS, 0, 0, pack('nN', 0x5, 32768)),
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM,
+                1,
+                "\x82\x87\x41\x0bexample.com\x44\x06/hello"
+            ),
+        ];
+
+        $connection = new H2ServerConnection(connection: $queuedConnection);
+        $result = $connection->recvStreamRequest();
+
+        $this->assertSame(1, $result['streamId']);
+        $this->assertCount(1, $queuedConnection->sentFrames);
+        $this->assertSame(H2Frame::TYPE_SETTINGS, $queuedConnection->sentFrames[0]->type);
+        $this->assertSame(H2Frame::FLAG_ACK, $queuedConnection->sentFrames[0]->flags);
+    }
+
+    public function testRecvStreamRequestPumpsPingBeforeHeadersAndSendsAck(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+            /** @var list<H2Frame> */
+            public array $sentFrames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->sentFrames[] = $frame;
+            }
+        };
+        $queuedConnection->frames = [
+            new H2Frame(H2Frame::TYPE_PING, 0, 0, '12345678'),
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM,
+                1,
+                "\x82\x87\x41\x0bexample.com\x44\x06/hello"
+            ),
+        ];
+
+        $connection = new H2ServerConnection(connection: $queuedConnection);
+        $result = $connection->recvStreamRequest();
+
+        $this->assertSame(1, $result['streamId']);
+        $this->assertCount(1, $queuedConnection->sentFrames);
+        $this->assertSame(H2Frame::TYPE_PING, $queuedConnection->sentFrames[0]->type);
+        $this->assertSame(H2Frame::FLAG_ACK, $queuedConnection->sentFrames[0]->flags);
+        $this->assertSame('12345678', $queuedConnection->sentFrames[0]->payload);
+    }
+
+    public function testRecvRequestRejectsEmptyHeadersPayload(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+        };
+        $queuedConnection->frames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS, 1, ''),
+        ];
+
+        $connection = new H2ServerConnection(connection: $queuedConnection);
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('HEADERS frame payload must not be empty');
+
+        $connection->recvRequest();
+    }
+
+    public function testRecvRequestRejectsNewStreamAfterGoAwayAndSendsRstStream(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+            /** @var list<H2Frame> */
+            public array $sentFrames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->sentFrames[] = $frame;
+            }
+        };
+        $queuedConnection->validateFrame(new H2Frame(H2Frame::TYPE_GOAWAY, 0, 0, pack('NN', 1, H2Exception::ERROR_NO_ERROR)));
+        $queuedConnection->frames = [
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM,
+                3,
+                "\x82\x87\x41\x0bexample.com\x44\x06/hello"
+            ),
+        ];
+
+        $connection = new H2ServerConnection(connection: $queuedConnection);
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('New stream is not allowed after GOAWAY');
+
+        try {
+            $connection->recvRequest();
+        } finally {
+            $this->assertCount(1, $queuedConnection->sentFrames);
+            $this->assertSame(H2Frame::TYPE_RST_STREAM, $queuedConnection->sentFrames[0]->type);
+            $this->assertSame(3, $queuedConnection->sentFrames[0]->streamId);
+            $this->assertSame(pack('N', H2Exception::ERROR_REFUSED_STREAM), $queuedConnection->sentFrames[0]->payload);
+        }
+    }
+
+    public function testRecvRequestRejectsHeadersForAlreadyClosedStream(): void
+    {
+        $queuedConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+            /** @var list<H2Frame> */
+            public array $sentFrames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->sentFrames[] = $frame;
+            }
+        };
+        $queuedConnection->sendRstStream(1, H2Exception::ERROR_CANCEL);
+        $queuedConnection->frames = [
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM,
+                1,
+                "\x82\x87\x41\x0bexample.com\x44\x06/hello"
+            ),
+        ];
+
+        $connection = new H2ServerConnection(connection: $queuedConnection);
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Frame received for closed stream');
+
+        $connection->recvRequest();
+    }
+}

--- a/lib/swow-library/tests/Psr7/Server/H2ServerResponseFlowTest.php
+++ b/lib/swow-library/tests/Psr7/Server/H2ServerResponseFlowTest.php
@@ -1,0 +1,2017 @@
+<?php
+
+/**
+ * This file is part of Swow
+ *
+ * @link    https://github.com/swow/swow
+ * @contact twosee <twosee@php.net>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code
+ */
+
+declare(strict_types=1);
+
+namespace Swow\Tests\Psr7\Server;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Swow\Http\Protocol\H2Connection;
+use Swow\Http\Protocol\H2Exception;
+use Swow\Http\Protocol\H2Frame;
+use Swow\Psr7\Psr7;
+use Swow\Psr7\Server\H2ResponseEnvelope;
+use Swow\Psr7\Server\H2ServerConnection;
+use Swow\Socket;
+use Swow\SocketException;
+
+use function array_map;
+use function implode;
+use function str_repeat;
+use function strlen;
+
+/**
+ * @internal
+ */
+#[CoversClass(H2ServerConnection::class)]
+final class H2ServerResponseFlowTest extends TestCase
+{
+    public function testHandleOneRequestSendsHeadersOnlyForEmptyBodyResponse(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->streamReceiveWindows[1] = 2;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $streamId = $connection->handleOneRequest(
+            static fn($request) => Psr7::createResponse(204)
+        );
+
+        $this->assertSame(1, $streamId);
+        $this->assertCount(1, $recordingConnection->writtenFrames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $recordingConnection->writtenFrames[0]->type);
+        $this->assertSame(H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, $recordingConnection->writtenFrames[0]->flags);
+    }
+
+    public function testHandleOneRequestSendsHeadersThenDataForBodyResponse(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->streamReceiveWindows[1] = 2;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $streamId = $connection->handleOneRequest(
+            static fn($request) => Psr7::createResponse(200, headers: ['x-a' => 'b'], body: 'hello')
+        );
+
+        $this->assertSame(1, $streamId);
+        $this->assertCount(2, $recordingConnection->writtenFrames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $recordingConnection->writtenFrames[0]->type);
+        $this->assertSame(H2Frame::FLAG_END_HEADERS, $recordingConnection->writtenFrames[0]->flags);
+        $this->assertSame(H2Frame::TYPE_DATA, $recordingConnection->writtenFrames[1]->type);
+        $this->assertSame('hello', $recordingConnection->writtenFrames[1]->payload);
+        $this->assertSame(H2Frame::FLAG_END_STREAM, $recordingConnection->writtenFrames[1]->flags);
+    }
+
+    public function testHandleOneRequestSupportsResponseEnvelopeWithTrailers(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->handleOneRequest(
+            static fn($request) => H2ResponseEnvelope::from(
+                Psr7::createResponse(200, body: 'ok'),
+                ['x-trailer' => 'done']
+            )
+        );
+
+        $this->assertCount(3, $recordingConnection->writtenFrames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $recordingConnection->writtenFrames[0]->type);
+        $this->assertSame(H2Frame::TYPE_DATA, $recordingConnection->writtenFrames[1]->type);
+        $this->assertSame(0, $recordingConnection->writtenFrames[1]->flags);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $recordingConnection->writtenFrames[2]->type);
+        $this->assertSame(H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, $recordingConnection->writtenFrames[2]->flags);
+    }
+
+    public function testHandleRequestsProcessesElevenStreamsWithBodiesAndBidirectionalTrailers(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+
+        foreach (range(1, 11) as $index) {
+            $streamId = ($index * 2) - 1;
+            $path = '/s' . $index;
+            $body = 'body-' . $index;
+            $trailerValue = 't' . $index;
+
+            $recordingConnection->readFrames[] = new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS,
+                $streamId,
+                "\x82\x87\x41\x0bexample.com\x44" . chr(strlen($path)) . $path
+            );
+            $recordingConnection->readFrames[] = new H2Frame(H2Frame::TYPE_DATA, 0, $streamId, $body);
+            $recordingConnection->readFrames[] = new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM,
+                $streamId,
+                "\x40\x10x-client-trailer" . chr(strlen($trailerValue)) . $trailerValue
+            );
+        }
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $handled = $connection->handleRequests(
+            static function ($request, int $streamId): H2ResponseEnvelope {
+                $index = intdiv($streamId + 1, 2);
+
+                return H2ResponseEnvelope::from(
+                    response: Psr7::createResponse(200, body: 'resp-' . $index),
+                    trailers: ['x-server-trailer' => 'done-' . $index]
+                );
+            },
+            limit: 11
+        );
+
+        $this->assertSame(11, $handled);
+        $this->assertCount(33, $recordingConnection->writtenFrames);
+        foreach (range(0, 10) as $offset) {
+            $frameBase = $offset * 3;
+            $streamId = (($offset + 1) * 2) - 1;
+            $index = $offset + 1;
+            $this->assertSame(H2Frame::TYPE_HEADERS, $recordingConnection->writtenFrames[$frameBase]->type);
+            $this->assertSame($streamId, $recordingConnection->writtenFrames[$frameBase]->streamId);
+            $this->assertSame(H2Frame::TYPE_DATA, $recordingConnection->writtenFrames[$frameBase + 1]->type);
+            $this->assertSame('resp-' . $index, $recordingConnection->writtenFrames[$frameBase + 1]->payload);
+            $this->assertSame(H2Frame::TYPE_HEADERS, $recordingConnection->writtenFrames[$frameBase + 2]->type);
+            $this->assertSame(H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, $recordingConnection->writtenFrames[$frameBase + 2]->flags);
+        }
+    }
+
+    public function testHandleOneRequestAcceptsArrayResponseWithTrailingHeaders(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->handleOneRequest(
+            static fn($request): array => [201, ['x-header' => 'yes'], 'ok', ['x-trailer' => 'done']]
+        );
+
+        $this->assertCount(3, $recordingConnection->writtenFrames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $recordingConnection->writtenFrames[0]->type);
+        $this->assertSame(H2Frame::TYPE_DATA, $recordingConnection->writtenFrames[1]->type);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $recordingConnection->writtenFrames[2]->type);
+    }
+
+    public function testHandleOneRequestAcceptsNamedResponseMapWithTrailers(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->handleOneRequest(
+            static fn($request): array => [
+                'status' => 202,
+                'headers' => ['x-header' => 'yes'],
+                'body' => 'ok',
+                'trailers' => ['x-trailer' => 'done'],
+            ]
+        );
+
+        $this->assertCount(3, $recordingConnection->writtenFrames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $recordingConnection->writtenFrames[0]->type);
+        $this->assertSame(H2Frame::TYPE_DATA, $recordingConnection->writtenFrames[1]->type);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $recordingConnection->writtenFrames[2]->type);
+    }
+
+    public function testHandleOneRequestDoesNotSwallowHandlerException(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x01/"),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('boom');
+
+        try {
+            $connection->handleOneRequest(
+                static function ($request) {
+                    throw new \RuntimeException('boom');
+                }
+            );
+        } finally {
+            $this->assertCount(0, $recordingConnection->writtenFrames);
+        }
+    }
+
+    public function testHandleRequestsProcessesMultipleRequestsSequentially(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x02/a"),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 3, "\x82\x87\x41\x0bexample.com\x44\x02/b"),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $handled = $connection->handleRequests(
+            static fn($request, int $streamId) => Psr7::createResponse(204),
+            limit: 2
+        );
+
+        $this->assertSame(2, $handled);
+        $this->assertCount(2, $recordingConnection->writtenFrames);
+        $this->assertSame(1, $recordingConnection->writtenFrames[0]->streamId);
+        $this->assertSame(3, $recordingConnection->writtenFrames[1]->streamId);
+    }
+
+    public function testHandleRequestsContinuesAfterStreamLevelError(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->streamReceiveWindows[1] = 2;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS, 1, "\x82\x87\x41\x0bexample.com\x44\x05/echo"),
+            new H2Frame(H2Frame::TYPE_DATA, H2Frame::FLAG_END_STREAM, 1, 'abc'),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 5, "\x82\x87\x41\x0bexample.com\x44\x03/ok"),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $handled = $connection->handleRequests(
+            static fn($request, int $streamId) => Psr7::createResponse(204),
+            limit: 1
+        );
+
+        $this->assertSame(1, $handled);
+        $this->assertCount(2, $recordingConnection->writtenFrames);
+        $this->assertSame(H2Frame::TYPE_RST_STREAM, $recordingConnection->writtenFrames[0]->type);
+        $this->assertSame(1, $recordingConnection->writtenFrames[0]->streamId);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $recordingConnection->writtenFrames[1]->type);
+        $this->assertSame(5, $recordingConnection->writtenFrames[1]->streamId);
+    }
+
+    public function testHandleRequestsHonorsLimit(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x02/a"),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 3, "\x82\x87\x41\x0bexample.com\x44\x02/b"),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $handled = $connection->handleRequests(
+            static fn($request, int $streamId) => Psr7::createResponse(204),
+            limit: 1
+        );
+
+        $this->assertSame(1, $handled);
+        $this->assertCount(1, $recordingConnection->writtenFrames);
+        $this->assertCount(1, $recordingConnection->readFrames);
+    }
+
+    public function testHandleRequestsReturnsZeroWhenLimitIsZero(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x02/a"),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $handled = $connection->handleRequests(
+            static fn($request, int $streamId) => Psr7::createResponse(204),
+            limit: 0
+        );
+
+        $this->assertSame(0, $handled);
+        $this->assertCount(0, $recordingConnection->writtenFrames);
+        $this->assertCount(1, $recordingConnection->readFrames);
+    }
+
+    public function testHandleRequestsContinuesAfterHandlerThrowsStreamLevelH2Exception(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x02/a"),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 3, "\x82\x87\x41\x0bexample.com\x44\x02/b"),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $calls = 0;
+        $handled = $connection->handleRequests(
+            static function ($request, int $streamId) use (&$calls) {
+                $calls++;
+                if ($calls === 1) {
+                    throw H2Exception::forStreamError($streamId, 'handler stream error', H2Exception::ERROR_CANCEL);
+                }
+
+                return Psr7::createResponse(204);
+            },
+            limit: 1
+        );
+
+        $this->assertSame(1, $handled);
+        $this->assertCount(2, $recordingConnection->writtenFrames);
+        $this->assertSame(H2Frame::TYPE_RST_STREAM, $recordingConnection->writtenFrames[0]->type);
+        $this->assertSame(1, $recordingConnection->writtenFrames[0]->streamId);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $recordingConnection->writtenFrames[1]->type);
+        $this->assertSame(3, $recordingConnection->writtenFrames[1]->streamId);
+    }
+
+    public function testHandleRequestsStopsWhenHandlerThrowsConnectionLevelH2Exception(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $frame;
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x02/a"),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('handler connection error');
+
+        try {
+            $connection->handleRequests(
+                static fn($request, int $streamId) => throw H2Exception::forConnectionError('handler connection error'),
+                limit: 1
+            );
+        } finally {
+            $this->assertCount(0, $recordingConnection->writtenFrames);
+        }
+    }
+
+    public function testHandleRequestsProcessesWindowUpdateBetweenRequests(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->connectionSendWindow = 64;
+                $this->streamSendWindows[1] = 64;
+                $this->streamSendWindows[3] = 64;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x02/a"),
+            new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 0, pack('N', 16)),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 3, "\x82\x87\x41\x0bexample.com\x44\x02/b"),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $handled = $connection->handleRequests(
+            static fn($request, int $streamId) => Psr7::createResponse(204),
+            limit: 2
+        );
+
+        $this->assertSame(2, $handled);
+        $this->assertCount(2, $recordingConnection->writtenFrames);
+        $this->assertSame(1, $recordingConnection->writtenFrames[0]->streamId);
+        $this->assertSame(3, $recordingConnection->writtenFrames[1]->streamId);
+    }
+
+    public function testHandleRequestsStopsNaturallyAfterGoAwayFinishesAllowedRange(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x02/a"),
+            new H2Frame(H2Frame::TYPE_GOAWAY, 0, 0, pack('NN', 1, H2Exception::ERROR_NO_ERROR)),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $handled = $connection->handleRequests(
+            static fn($request, int $streamId) => Psr7::createResponse(204),
+            limit: null
+        );
+
+        $this->assertSame(1, $handled);
+        $this->assertCount(1, $recordingConnection->writtenFrames);
+        $this->assertSame(1, $recordingConnection->writtenFrames[0]->streamId);
+    }
+
+    public function testHandleRequestsStopsNaturallyWhenOnlyGoAwayIsReceived(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_GOAWAY, 0, 0, pack('NN', 0, H2Exception::ERROR_NO_ERROR)),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $handled = $connection->handleRequests(
+            static fn($request, int $streamId) => Psr7::createResponse(204),
+            limit: null
+        );
+
+        $this->assertSame(0, $handled);
+        $this->assertCount(0, $recordingConnection->writtenFrames);
+    }
+
+    public function testHandleRequestsStopsNaturallyAfterOneRequestThenEof(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if ($frame instanceof H2Frame) {
+                    return $frame;
+                }
+
+                throw new SocketException('Connection has been closed');
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82\x87\x41\x0bexample.com\x44\x02/a"),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $handled = $connection->handleRequests(
+            static fn($request, int $streamId) => Psr7::createResponse(204),
+            limit: null
+        );
+
+        $this->assertSame(1, $handled);
+        $this->assertCount(1, $recordingConnection->writtenFrames);
+    }
+
+    public function testHandleRequestsReturnsZeroOnImmediateEof(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $writtenFrames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                throw new SocketException('Connection has been closed');
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->writtenFrames[] = $frame;
+            }
+        };
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $handled = $connection->handleRequests(
+            static fn($request, int $streamId) => Psr7::createResponse(204),
+            limit: null
+        );
+
+        $this->assertSame(0, $handled);
+        $this->assertCount(0, $recordingConnection->writtenFrames);
+    }
+
+    public function testHandleRequestsStillThrowsNonEofReadException(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                throw new \RuntimeException('boom');
+            }
+        };
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('boom');
+
+        $connection->handleRequests(
+            static fn($request, int $streamId) => Psr7::createResponse(204),
+            limit: null
+        );
+    }
+
+    public function testSendResponseSplitsLargeHeadersAndBodyTogether(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->validateFrame(new H2Frame(H2Frame::TYPE_SETTINGS, 0, 0, pack('nN', 0x5, 20000)));
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $response = Psr7::createResponse(200, headers: ['x-long' => str_repeat('z', 21000)], body: str_repeat('a', 21000));
+
+        $connection->sendResponse(1, $response);
+
+        $this->assertCount(4, $recordingConnection->frames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $recordingConnection->frames[0]->type);
+        $this->assertSame(H2Frame::TYPE_CONTINUATION, $recordingConnection->frames[1]->type);
+        $this->assertSame(H2Frame::TYPE_DATA, $recordingConnection->frames[2]->type);
+        $this->assertSame(H2Frame::TYPE_DATA, $recordingConnection->frames[3]->type);
+        $this->assertSame(H2Frame::FLAG_END_STREAM, $recordingConnection->frames[3]->flags);
+        $this->assertSame(20000, strlen($recordingConnection->frames[2]->payload));
+        $this->assertSame(1000, strlen($recordingConnection->frames[3]->payload));
+    }
+
+    public function testSendResponseDataUsesSingleFrameForSmallPayload(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseData(1, 'hello', true);
+
+        $this->assertCount(1, $recordingConnection->frames);
+        $this->assertSame('hello', $recordingConnection->frames[0]->payload);
+        $this->assertSame(H2Frame::FLAG_END_STREAM, $recordingConnection->frames[0]->flags);
+    }
+
+    public function testSendResponseDataSplitsLargePayloadIntoMultipleFrames(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+
+        $payload = str_repeat('a', H2Frame::DEFAULT_MAX_FRAME_SIZE + 10);
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseData(1, $payload, true);
+
+        $this->assertCount(2, $recordingConnection->frames);
+        $this->assertSame(H2Frame::DEFAULT_MAX_FRAME_SIZE, strlen($recordingConnection->frames[0]->payload));
+        $this->assertSame(10, strlen($recordingConnection->frames[1]->payload));
+        $this->assertSame(0, $recordingConnection->frames[0]->flags);
+        $this->assertSame(H2Frame::FLAG_END_STREAM, $recordingConnection->frames[1]->flags);
+        $this->assertSame(
+            $payload,
+            implode('', array_map(static fn(H2Frame $frame): string => $frame->payload, $recordingConnection->frames))
+        );
+    }
+
+    public function testSendResponseDataUsesNegotiatedMaxFrameSize(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+
+        $recordingConnection->validateFrame(new H2Frame(H2Frame::TYPE_SETTINGS, 0, 0, pack('nN', 0x5, 32768)));
+
+        $payload = str_repeat('b', 32769);
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseData(1, $payload, true);
+
+        $this->assertCount(2, $recordingConnection->frames);
+        $this->assertSame(32768, strlen($recordingConnection->frames[0]->payload));
+        $this->assertSame(1, strlen($recordingConnection->frames[1]->payload));
+        $this->assertSame(0, $recordingConnection->frames[0]->flags);
+        $this->assertSame(H2Frame::FLAG_END_STREAM, $recordingConnection->frames[1]->flags);
+    }
+
+    public function testSendResponseDataConsumesSendWindowsAndSplitsBySmallestWindow(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->connectionSendWindow = 4;
+                $this->streamSendWindows[1] = 3;
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+
+            public function exposeConnectionSendWindow(): int
+            {
+                return $this->connectionSendWindow;
+            }
+
+            public function exposeStreamSendWindow(int $streamId): int
+            {
+                return $this->streamSendWindows[$streamId] ?? self::DEFAULT_INITIAL_WINDOW_SIZE;
+            }
+        };
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseData(1, 'abc', true);
+
+        $this->assertCount(1, $recordingConnection->frames);
+        $this->assertSame('abc', $recordingConnection->frames[0]->payload);
+        $this->assertSame(1, $recordingConnection->exposeConnectionSendWindow());
+        $this->assertSame(0, $recordingConnection->exposeStreamSendWindow(1));
+    }
+
+    public function testSendResponseDataRejectsWhenConnectionSendWindowIsZero(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->connectionSendWindow = 0;
+            }
+        };
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+
+        $this->expectException(\Swow\Http\Protocol\H2Exception::class);
+        $this->expectExceptionMessage('Connection send window exhausted');
+
+        $connection->sendResponseData(1, 'a', true);
+    }
+
+    public function testSendResponseDataRejectsWhenStreamSendWindowIsZero(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->streamSendWindows[1] = 0;
+            }
+        };
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+
+        $this->expectException(\Swow\Http\Protocol\H2Exception::class);
+        $this->expectExceptionMessage('Stream send window exhausted');
+
+        $connection->sendResponseData(1, 'a', true);
+    }
+
+    public function testSendResponseDataUsesUpdatedInitialWindowSizeForNewStreamSendWindow(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->validateFrame(new H2Frame(H2Frame::TYPE_SETTINGS, 0, 0, pack('nN', 0x4, 2)));
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $this->expectException(\Swow\Http\Protocol\H2Exception::class);
+        $this->expectExceptionMessage('Stream send window exhausted');
+
+        try {
+            $connection->sendResponseData(3, 'abc', true);
+        } finally {
+            $this->assertCount(1, $recordingConnection->frames);
+            $this->assertSame('ab', $recordingConnection->frames[0]->payload);
+        }
+    }
+
+    public function testSendResponseDataWaitsForWindowUpdateAndResumesInSingleCall(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->streamSendWindows[1] = 2;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 1, pack('N', 2)),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseData(1, 'abcd', true);
+
+        $this->assertCount(2, $recordingConnection->frames);
+        $this->assertSame('ab', $recordingConnection->frames[0]->payload);
+        $this->assertSame('cd', $recordingConnection->frames[1]->payload);
+        $this->assertSame(H2Frame::FLAG_END_STREAM, $recordingConnection->frames[1]->flags);
+    }
+
+    public function testSendResponseDataWaitFailsWhenRstStreamArrives(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->streamSendWindows[1] = 0;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            H2Frame::createRstStream(1, H2Exception::ERROR_CANCEL),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('Cannot send on locally closed stream');
+
+        $connection->sendResponseData(1, 'body', true);
+    }
+
+    public function testSendResponseDataWaitKeepsQueuedRequestAfterRstStreamInterrupt(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->streamSendWindows[1] = 0;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 3, "\x82\x87\x41\x0bexample.com\x44\x05/next"),
+            H2Frame::createRstStream(1, H2Exception::ERROR_CANCEL),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+
+        try {
+            $connection->sendResponseData(1, 'body', true);
+            $this->fail('Expected sendResponseData() to fail after RST_STREAM');
+        } catch (H2Exception $exception) {
+            $this->assertSame('Cannot send on locally closed stream', $exception->getMessage());
+        }
+
+        $streamRequest = $connection->tryRecvStreamRequest();
+
+        $this->assertNotNull($streamRequest);
+        $this->assertSame(3, $streamRequest['streamId']);
+        $this->assertSame('/next', $streamRequest['request']->getUri()->getPath());
+    }
+
+    public function testSendResponseDataWaitPreservesQueuedRequestFrames(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->streamSendWindows[1] = 0;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 3, "\x82\x87\x41\x0bexample.com\x44\x05/next"),
+            new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 1, pack('N', 2)),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseData(1, 'ok', true);
+        $streamRequest = $connection->tryRecvStreamRequest();
+
+        $this->assertCount(1, $recordingConnection->frames);
+        $this->assertSame('ok', $recordingConnection->frames[0]->payload);
+        $this->assertNotNull($streamRequest);
+        $this->assertSame(3, $streamRequest['streamId']);
+        $this->assertSame('/next', $streamRequest['request']->getUri()->getPath());
+    }
+
+    public function testSendResponseDataWaitPreservesMultipleQueuedRequestFramesInOrder(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->streamSendWindows[1] = 0;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 3, "\x82\x87\x41\x0bexample.com\x44\x03/aa"),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 5, "\x82\x87\x41\x0bexample.com\x44\x03/bb"),
+            new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 1, pack('N', 2)),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseData(1, 'ok', true);
+        $first = $connection->tryRecvStreamRequest();
+        $second = $connection->tryRecvStreamRequest();
+
+        $this->assertCount(1, $recordingConnection->frames);
+        $this->assertSame('ok', $recordingConnection->frames[0]->payload);
+        $this->assertSame(3, $first['streamId']);
+        $this->assertSame('/aa', $first['request']->getUri()->getPath());
+        $this->assertSame(5, $second['streamId']);
+        $this->assertSame('/bb', $second['request']->getUri()->getPath());
+    }
+
+    public function testSendResponseDataWaitPreservesDeferredHeaderBlocksAcrossStreams(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->streamSendWindows[1] = 0;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, 0, 3, "\x82\x87"),
+            new H2Frame(H2Frame::TYPE_CONTINUATION, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 3, "\x41\x0bexample.com\x44\x03/aa"),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 5, "\x82\x87\x41\x0bexample.com\x44\x03/bb"),
+            new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 1, pack('N', 2)),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseData(1, 'ok', true);
+        $first = $connection->tryRecvStreamRequest();
+        $second = $connection->tryRecvStreamRequest();
+
+        $this->assertCount(1, $recordingConnection->frames);
+        $this->assertSame('ok', $recordingConnection->frames[0]->payload);
+        $this->assertSame(3, $first['streamId']);
+        $this->assertSame('/aa', $first['request']->getUri()->getPath());
+        $this->assertSame(5, $second['streamId']);
+        $this->assertSame('/bb', $second['request']->getUri()->getPath());
+    }
+
+    public function testPendingControlFramesArePumpedBeforeDeferredRequestStartFrames(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->streamSendWindows[1] = 0;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 3, "\x82\x87\x41\x0bexample.com\x44\x03/aa"),
+            new H2Frame(H2Frame::TYPE_GOAWAY, 0, 0, pack('NN', 1, H2Exception::ERROR_NO_ERROR)),
+            new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 1, pack('N', 2)),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseData(1, 'ok', true);
+
+        $this->expectException(H2Exception::class);
+        $this->expectExceptionMessage('New stream is not allowed after GOAWAY');
+
+        $connection->tryRecvStreamRequest();
+    }
+
+    public function testPendingGoAwayStillAllowsDeferredRequestWithinAllowedRange(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->streamSendWindows[1] = 0;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 3, "\x82\x87\x41\x0bexample.com\x44\x03/ok"),
+            new H2Frame(H2Frame::TYPE_GOAWAY, 0, 0, pack('NN', 3, H2Exception::ERROR_NO_ERROR)),
+            new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 1, pack('N', 2)),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseData(1, 'ok', true);
+        $streamRequest = $connection->tryRecvStreamRequest();
+
+        $this->assertNotNull($streamRequest);
+        $this->assertSame(3, $streamRequest['streamId']);
+        $this->assertSame('/ok', $streamRequest['request']->getUri()->getPath());
+    }
+
+    public function testSendResponseDataWaitHandlesGoAwayWindowUpdateAndRstStreamSequence(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->streamSendWindows[1] = 0;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 3, "\x82\x87\x41\x0bexample.com\x44\x05/next"),
+            new H2Frame(H2Frame::TYPE_GOAWAY, 0, 0, pack('NN', 3, H2Exception::ERROR_NO_ERROR)),
+            new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 1, pack('N', 2)),
+            H2Frame::createRstStream(1, H2Exception::ERROR_CANCEL),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+
+        try {
+            $connection->sendResponseData(1, 'abcd', true);
+            $this->fail('Expected sendResponseData() to stop after RST_STREAM');
+        } catch (H2Exception $exception) {
+            $this->assertSame('Cannot send on locally closed stream', $exception->getMessage());
+        }
+
+        $this->assertCount(1, $recordingConnection->frames);
+        $this->assertSame('ab', $recordingConnection->frames[0]->payload);
+
+        $streamRequest = $connection->tryRecvStreamRequest();
+        $this->assertNotNull($streamRequest);
+        $this->assertSame(3, $streamRequest['streamId']);
+        $this->assertSame('/next', $streamRequest['request']->getUri()->getPath());
+    }
+
+    public function testSendResponseHeadersDoNotConsumeCumulativeSendWindow(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->connectionSendWindow = 64;
+                $this->streamSendWindows[1] = 64;
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+
+            public function exposeConnectionSendWindow(): int
+            {
+                return $this->connectionSendWindow;
+            }
+
+            public function exposeStreamSendWindow(int $streamId): int
+            {
+                return $this->streamSendWindows[$streamId] ?? self::DEFAULT_INITIAL_WINDOW_SIZE;
+            }
+        };
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseHeaders(1, 200, ['x-a' => 'b']);
+        $connection->sendResponseData(1, 'hello', true);
+
+        $this->assertCount(2, $recordingConnection->frames);
+        $consumed = strlen($recordingConnection->frames[1]->payload);
+        $this->assertSame(64 - $consumed, $recordingConnection->exposeConnectionSendWindow());
+        $this->assertSame(64 - $consumed, $recordingConnection->exposeStreamSendWindow(1));
+    }
+
+    public function testSendResponseDataHandlesMultipleSmallWindowUpdatesAcrossStreams(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->connectionSendWindow = 1;
+                $this->streamSendWindows[1] = 1;
+                $this->streamSendWindows[3] = 1;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 3, "\x82\x87\x41\x0bexample.com\x44\x03/s3"),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 5, "\x82\x87\x41\x0bexample.com\x44\x03/s5"),
+            new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 0, pack('N', 1)),
+            new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 1, pack('N', 1)),
+            new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 0, pack('N', 1)),
+            new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 1, pack('N', 1)),
+            new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 0, pack('N', 1)),
+            new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 3, pack('N', 1)),
+            new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 0, pack('N', 1)),
+            new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 3, pack('N', 1)),
+            new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 0, pack('N', 1)),
+            new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 3, pack('N', 1)),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseData(1, 'abc', true);
+
+        $first = $connection->tryRecvStreamRequest();
+        $connection->sendResponseData(3, 'xyz', true);
+        $second = $connection->tryRecvStreamRequest();
+
+        $this->assertSame(3, $first['streamId']);
+        $this->assertSame('/s3', $first['request']->getUri()->getPath());
+        $this->assertSame(5, $second['streamId']);
+        $this->assertSame('/s5', $second['request']->getUri()->getPath());
+        $this->assertSame(
+            ['a', 'b', 'c', 'x', 'y', 'z'],
+            array_map(static fn(H2Frame $frame): string => $frame->payload, $recordingConnection->frames)
+        );
+    }
+
+    public function testSendResponseDataHandlesLargeBodyAcrossManyWindowUpdates(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->connectionSendWindow = 4;
+                $this->streamSendWindows[1] = 4;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        foreach (range(1, 8) as $_) {
+            $recordingConnection->readFrames[] = new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 0, pack('N', 4));
+            $recordingConnection->readFrames[] = new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 1, pack('N', 4));
+        }
+
+        $payload = str_repeat('x', 36);
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseData(1, $payload, true);
+
+        $this->assertSame($payload, implode('', array_map(static fn(H2Frame $frame): string => $frame->payload, $recordingConnection->frames)));
+        $this->assertSame(H2Frame::FLAG_END_STREAM, $recordingConnection->frames[array_key_last($recordingConnection->frames)]->flags);
+        $this->assertGreaterThan(8, count($recordingConnection->frames));
+    }
+
+    public function testHalfClosedLocalAllowsWindowUpdateAndGoAwayButRstStreamCloses(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+
+            public function exposeStreamSendWindow(int $streamId): int
+            {
+                return $this->streamSendWindows[$streamId] ?? self::DEFAULT_INITIAL_WINDOW_SIZE;
+            }
+        };
+        $recordingConnection->markRequestStreamProcessed(1);
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseHeaders(1, 204, [], true);
+
+        $recordingConnection->validateFrame(new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 1, pack('N', 1024)));
+        $recordingConnection->validateFrame(new H2Frame(H2Frame::TYPE_GOAWAY, 0, 0, pack('NN', 1, H2Exception::ERROR_NO_ERROR)));
+
+        $this->assertSame(H2Connection::STREAM_STATE_HALF_CLOSED_LOCAL, $recordingConnection->getStreamState(1));
+        $this->assertSame(H2Connection::DEFAULT_INITIAL_WINDOW_SIZE + 1024, $recordingConnection->exposeStreamSendWindow(1));
+
+        $recordingConnection->validateFrame(H2Frame::createRstStream(1, H2Exception::ERROR_CANCEL));
+
+        $this->assertTrue($recordingConnection->isStreamClosed(1));
+        $this->assertSame(H2Connection::STREAM_STATE_CLOSED, $recordingConnection->getStreamState(1));
+    }
+
+    public function testSendResponseDataPreservesFiveQueuedRequestFramesInOrder(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->streamSendWindows[1] = 0;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 3, "\x82\x87\x41\x0bexample.com\x44\x03/a1"),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 5, "\x82\x87\x41\x0bexample.com\x44\x03/a2"),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 7, "\x82\x87\x41\x0bexample.com\x44\x03/a3"),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 9, "\x82\x87\x41\x0bexample.com\x44\x03/a4"),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 11, "\x82\x87\x41\x0bexample.com\x44\x03/a5"),
+            new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 1, pack('N', 2)),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseData(1, 'ok', true);
+
+        $streamIds = [];
+        foreach (range(1, 5) as $_) {
+            $streamIds[] = $connection->tryRecvStreamRequest()['streamId'];
+        }
+
+        $this->assertSame([3, 5, 7, 9, 11], $streamIds);
+    }
+
+    public function testPendingGoAwayAllowsQueuedExistingStreamButRejectsQueuedNewStream(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->streamSendWindows[1] = 0;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 3, "\x82\x87\x41\x0bexample.com\x44\x03/s3"),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 5, "\x82\x87\x41\x0bexample.com\x44\x03/s5"),
+            new H2Frame(H2Frame::TYPE_GOAWAY, 0, 0, pack('NN', 3, H2Exception::ERROR_NO_ERROR)),
+            new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 1, pack('N', 2)),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseData(1, 'ok', true);
+
+        $allowed = $connection->tryRecvStreamRequest();
+        $this->assertSame(3, $allowed['streamId']);
+        $this->assertSame('/s3', $allowed['request']->getUri()->getPath());
+        $this->assertNull($connection->tryRecvStreamRequest());
+    }
+
+    public function testSendResponseDataPreservesNineQueuedRequestFramesInOrder(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->streamSendWindows[1] = 0;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 3, "\x82\x87\x41\x0bexample.com\x44\x03/r1"),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 5, "\x82\x87\x41\x0bexample.com\x44\x03/r2"),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 7, "\x82\x87\x41\x0bexample.com\x44\x03/r3"),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 9, "\x82\x87\x41\x0bexample.com\x44\x03/r4"),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 11, "\x82\x87\x41\x0bexample.com\x44\x03/r5"),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 13, "\x82\x87\x41\x0bexample.com\x44\x03/r6"),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 15, "\x82\x87\x41\x0bexample.com\x44\x03/r7"),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 17, "\x82\x87\x41\x0bexample.com\x44\x03/r8"),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 19, "\x82\x87\x41\x0bexample.com\x44\x03/r9"),
+            new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 1, pack('N', 2)),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseData(1, 'ok', true);
+
+        $streamIds = [];
+        foreach (range(1, 9) as $_) {
+            $streamIds[] = $connection->tryRecvStreamRequest()['streamId'];
+        }
+
+        $this->assertSame([3, 5, 7, 9, 11, 13, 15, 17, 19], $streamIds);
+    }
+
+    public function testPendingGoAwayPrefersQueuedOldStreamFramesOverQueuedNewStreamStarts(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function __construct(Socket $socket)
+            {
+                parent::__construct($socket);
+                $this->streamSendWindows[1] = 0;
+            }
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->markRequestStreamProcessed(3);
+        $recordingConnection->readFrames = [
+            new H2Frame(H2Frame::TYPE_DATA, H2Frame::FLAG_END_STREAM, 3, 'tail'),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 5, "\x82\x87\x41\x0bexample.com\x44\x03/n5"),
+            new H2Frame(H2Frame::TYPE_GOAWAY, 0, 0, pack('NN', 3, H2Exception::ERROR_NO_ERROR)),
+            new H2Frame(H2Frame::TYPE_WINDOW_UPDATE, 0, 1, pack('N', 2)),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseData(1, 'ok', true);
+
+        $body = $recordingConnection->readRequestBody(3);
+        $this->assertSame('tail', $body);
+        $this->assertNull($connection->tryRecvStreamRequest());
+    }
+
+    public function testHandleOneRequestSupportsRequestTrailerAndResponseTrailerOnSameStream(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $readFrames = [];
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->readFrames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->readFrames = [
+            new H2Frame(
+                H2Frame::TYPE_HEADERS,
+                H2Frame::FLAG_END_HEADERS,
+                1,
+                "\x82\x87\x41\x0bexample.com\x44\x05/echo"
+            ),
+            new H2Frame(H2Frame::TYPE_DATA, 0, 1, 'hello'),
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x40\x0ax-trailing\x03yes"),
+        ];
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $streamId = $connection->handleOneRequest(
+            static function ($request, int $streamId): H2ResponseEnvelope {
+                return H2ResponseEnvelope::from(
+                    response: Psr7::createResponse(200, body: 'ok'),
+                    trailers: ['x-server-trailer' => 'done']
+                );
+            }
+        );
+
+        $this->assertSame(1, $streamId);
+        $this->assertCount(3, $recordingConnection->frames);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $recordingConnection->frames[0]->type);
+        $this->assertSame(H2Frame::TYPE_DATA, $recordingConnection->frames[1]->type);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $recordingConnection->frames[2]->type);
+        $this->assertSame(H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, $recordingConnection->frames[2]->flags);
+    }
+
+    public function testSendResponseStillWorksForExistingStreamAfterGoAway(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->markRequestStreamProcessed(1);
+        $recordingConnection->goAway(lastStreamId: 1);
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseHeaders(1, 200, ['x-a' => 'b']);
+        $connection->sendResponseData(1, 'ok', true);
+
+        $this->assertCount(3, $recordingConnection->frames);
+        $this->assertSame(H2Frame::TYPE_GOAWAY, $recordingConnection->frames[0]->type);
+        $this->assertSame(H2Frame::TYPE_HEADERS, $recordingConnection->frames[1]->type);
+        $this->assertSame(H2Frame::TYPE_DATA, $recordingConnection->frames[2]->type);
+    }
+
+    public function testSendResponseRejectsNewStreamAfterGoAway(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->markRequestStreamProcessed(1);
+        $recordingConnection->goAway(lastStreamId: 1);
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+
+        $this->expectException(\Swow\Http\Protocol\H2Exception::class);
+        $this->expectExceptionMessage('New stream is not allowed after GOAWAY');
+
+        $connection->sendResponseData(3, 'x', true);
+    }
+
+    public function testSendResponseHeadersEndStreamMarksHalfClosedLocal(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->markRequestStreamProcessed(1);
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseHeaders(1, 200, ['x-a' => 'b'], true);
+
+        $this->assertSame(H2Connection::STREAM_STATE_HALF_CLOSED_LOCAL, $recordingConnection->getStreamState(1));
+    }
+
+    public function testSendResponseDataEndStreamClosesStreamAfterRemoteEnd(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function readFrame(?int $timeout = null): H2Frame
+            {
+                $frame = array_shift($this->frames);
+                if (!$frame instanceof H2Frame) {
+                    throw new \RuntimeException('No frame queued');
+                }
+
+                return $this->validateFrame($frame);
+            }
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->frames = [
+            new H2Frame(H2Frame::TYPE_HEADERS, H2Frame::FLAG_END_HEADERS | H2Frame::FLAG_END_STREAM, 1, "\x82"),
+        ];
+        $recordingConnection->readHeaderBlock();
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseData(1, 'ok', true);
+
+        $this->assertSame(H2Connection::STREAM_STATE_CLOSED, $recordingConnection->getStreamState(1));
+        $this->assertTrue($recordingConnection->isStreamClosed(1));
+    }
+
+    public function testSendResponseDataRejectsAfterLocalSideIsClosed(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->markRequestStreamProcessed(1);
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseHeaders(1, 200, ['x-a' => 'b'], true);
+
+        $this->expectException(\Swow\Http\Protocol\H2Exception::class);
+        $this->expectExceptionMessage('Cannot send on locally closed stream');
+
+        $connection->sendResponseData(1, 'late', true);
+    }
+
+    public function testSendResponseHeadersRejectsAfterLocalSideIsClosed(): void
+    {
+        $recordingConnection = new class(new Socket(Socket::TYPE_TCP)) extends H2Connection {
+            /** @var list<H2Frame> */
+            public array $frames = [];
+
+            public function sendFrame(H2Frame $frame, ?int $timeout = null): void
+            {
+                $this->frames[] = $frame;
+            }
+        };
+        $recordingConnection->markRequestStreamProcessed(1);
+
+        $connection = new H2ServerConnection(connection: $recordingConnection);
+        $connection->sendResponseHeaders(1, 200, ['x-a' => 'b'], true);
+
+        $this->expectException(\Swow\Http\Protocol\H2Exception::class);
+        $this->expectExceptionMessage('Cannot send on locally closed stream');
+
+        $connection->sendResponseHeaders(1, 200, ['x-b' => 'c']);
+    }
+}

--- a/lib/swow-library/tests/Psr7/Server/H2TrailersTest.php
+++ b/lib/swow-library/tests/Psr7/Server/H2TrailersTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swow\Tests\Psr7\Server;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Swow\Psr7\Server\H2ResponseEnvelope;
+use Swow\Psr7\Server\H2ServerConnection;
+use Swow\Psr7\Server\H2Trailers;
+use Swow\Psr7\Psr7;
+
+#[CoversClass(H2Trailers::class)]
+final class H2TrailersTest extends TestCase
+{
+    public function testTrailersObjectNormalizesScalarAndListValues(): void
+    {
+        $trailers = H2Trailers::fromArray([
+            'x-a' => '1',
+            'x-b' => ['2', '3'],
+        ]);
+
+        $this->assertSame(['1'], $trailers->get('x-a'));
+        $this->assertSame(['2', '3'], $trailers->get('x-b'));
+    }
+
+    public function testResponseEnvelopeAcceptsTrailersObject(): void
+    {
+        $envelope = H2ResponseEnvelope::from(
+            Psr7::createResponse(200),
+            H2Trailers::fromArray(['x-a' => 'done'])
+        );
+
+        $this->assertSame(['x-a' => ['done']], $envelope->trailersObject()->toArray());
+    }
+
+    public function testRequestTrailersObjectReturnsNormalizedTrailers(): void
+    {
+        $request = Psr7::createServerRequest('POST', 'https://example.com/', [])
+            ->withAttribute(H2ServerConnection::REQUEST_TRAILERS_ATTRIBUTE, ['x-a' => ['done']]);
+
+        $this->assertSame(
+            ['x-a' => ['done']],
+            H2ServerConnection::requestTrailersObject($request)->toArray()
+        );
+    }
+}


### PR DESCRIPTION
This PR targets `ci` by request and includes the full HTTP/2 runtime, ALPN integration, trailer support, scheduler/state-matrix refactor, and PHP 8.0 compatibility cleanup.