### PR TITLE
Fix curl async DNS poll scheduling

### DIFF
--- a/ext/deps/libcat/src/cat_curl.c
+++ b/ext/deps/libcat/src/cat_curl.c
@@ -39,6 +39,7 @@ typedef struct cat_curl_multi_context_s {
     CURLM *multi;
     uv_timer_t timer;
     cat_coroutine_t *waiter;
+    cat_event_io_defer_task_t *done_task;
     cat_msec_t timeout_due_time;
     cat_bool_t timedout; // timed out or initializing
     cat_queue_t socket_contexts;
@@ -157,6 +158,8 @@ static cat_always_inline void cat_curl_multi_socket_context_close(cat_curl_multi
     uv_close((uv_handle_t*) &socket_context->poll, cat_curl_multi_socket_context_close_callback);
 }
 
+static void cat_curl_multi_done_callback(cat_event_io_defer_task_t *task, cat_data_t *data);
+
 static cat_always_inline void cat_curl_multi_socket_schedule(cat_curl_multi_context_t *context, curl_socket_t sockfd, int action)
 {
     // insert to context->socket_contexts
@@ -175,6 +178,16 @@ static cat_always_inline void cat_curl_multi_socket_schedule(cat_curl_multi_cont
 #ifdef CAT_DEBUG
     CAT_ASSERT(found);
 #endif
+    if (context->waiter != NULL && context->done_task == NULL) {
+        context->done_task = cat_event_io_defer_task_create(cat_curl_multi_done_callback, context);
+    }
+}
+
+static void cat_curl_multi_done_callback(cat_event_io_defer_task_t *task, cat_data_t *data)
+{
+    cat_curl_multi_context_t *context = (cat_curl_multi_context_t *) data;
+
+    (void) task;
     if (context->waiter != NULL) {
         cat_coroutine_schedule(context->waiter, CURL, "Poll event from CURL socket function");
     }
@@ -361,6 +374,10 @@ static void cat_curl_multi_context_close(cat_curl_multi_context_t *context)
     if (context->waiter != NULL) {
         cat_coroutine_schedule(context->waiter, CURL, "Multi context close");
     }
+    if (context->done_task != NULL) {
+        cat_event_io_defer_task_close(context->done_task);
+        context->done_task = NULL;
+    }
     uv_close((uv_handle_t *) &context->timer, cat_curl_multi_context_close_callback);
     // should be empty, but if user called curl_multi_wait() and the transfer is not finished,
     // some sockets may not be removed from the multi context due to a curl bug.
@@ -395,6 +412,7 @@ static cat_curl_multi_context_t *cat_curl_multi_create_context(CURLM *multi)
 
     context->multi = multi;
     context->waiter = NULL;
+    context->done_task = NULL;
     context->timedout = cat_true;
     cat_queue_init(&context->socket_contexts);
     uv_timer_init(&CAT_EVENT_G(loop), &context->timer);
@@ -492,6 +510,10 @@ static CURLMcode cat_curl_multi_wait_impl(
         ret = cat_time_delay(-1);
     }
     context->waiter = NULL;
+    if (context->done_task != NULL) {
+        cat_event_io_defer_task_close(context->done_task);
+        context->done_task = NULL;
+    }
     if (unlikely(ret == CAT_RET_ERROR)) {
         // CAT_RET_ERROR for wait encountered errors
         mcode = CURLM_INTERNAL_ERROR;

--- a/ext/tests/swow_curl/easy_async_dns.phpt
+++ b/ext/tests/swow_curl/easy_async_dns.phpt
@@ -1,0 +1,35 @@
+--TEST--
+swow_curl: easy with async DNS
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.php';
+skip_if(PHP_SAPI !== 'cli', 'only for cli');
+skip_if(!Swow\Extension::isBuiltWith('curl'), 'extension must be built with libcurl');
+require __DIR__ . '/../include/bootstrap.php';
+skip_if(!(curl_version()['features'] & CURL_VERSION_ASYNCHDNS), 'libcurl must be built with async DNS');
+skip_if(!str_contains(@file_get_contents(TEST_WEBSITE1_URL), TEST_WEBSITE1_KEYWORD), 'Unable to access ' . TEST_WEBSITE1_URL);
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/../include/bootstrap.php';
+
+$ch = curl_init();
+Assert::notSame($ch, false);
+Assert::same(curl_setopt_array($ch, [
+    CURLOPT_URL => TEST_WEBSITE1_URL,
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_CONNECTTIMEOUT => 3,
+    CURLOPT_TIMEOUT => 5,
+    CURLOPT_SSL_VERIFYPEER => false,
+    CURLOPT_SSL_VERIFYHOST => 0,
+]), true);
+
+$response = curl_exec($ch);
+
+Assert::same(curl_errno($ch), 0, curl_error($ch));
+Assert::contains($response, TEST_WEBSITE1_KEYWORD);
+
+echo "Done\n";
+?>
+--EXPECT--
+Done


### PR DESCRIPTION
## Summary
- defer cURL poll wakeups to the I/O check phase so one event-loop round can collect all ready sockets before resuming the waiter
- prevent async DNS resolver pipe readiness from starving the subsequent connect socket writable event
- add a regression PHPT for cURL easy requests with async DNS

## Verification
- RED before the fix: `easy_async_dns.phpt` failed with `curl_errno=28 Connection timed out after 3000 milliseconds`
- GREEN after the fix: `php -d extension=/Users/xiejiabo/Documents/Code/swow/ext/modules/swow.so ext/run-tests.php -P -d extension=/Users/xiejiabo/Documents/Code/swow/ext/modules/swow.so --show-diff --set-timeout 20 ext/tests/swow_curl/easy_async_dns.phpt`
- `php -d extension=/Users/xiejiabo/Documents/Code/swow/ext/modules/swow.so ext/run-tests.php -P -d extension=/Users/xiejiabo/Documents/Code/swow/ext/modules/swow.so --show-diff --set-timeout 30 ext/tests/swow_curl`
- manual verification against the originally failing URL returned HTTP 200 with errno 0
